### PR TITLE
VAN-1868 switch gcloud creds

### DIFF
--- a/pipeline-modules/deployment-service/gcp/cloud-run.yaml
+++ b/pipeline-modules/deployment-service/gcp/cloud-run.yaml
@@ -76,18 +76,9 @@ template: |
 
   {% set workspace = '/workspace' %}   {# has to be a persistent volume #}
   {% set pipeline_env_file = workspace|add:'/.env' %}
-  {% set google_credentials_path = workspace|add:'/codepipes-user-sa.json' %}
 
   steps:
   {% if job_type == 'deploy' %}
-  - id: 'Switch gcloud auth'
-    name: 'gcr.io/cloud-builders/gcloud'
-    entrypoint: 'bash'
-    args:
-    - '-c'
-    - |
-      printf '%s' "$$GOOGLE_CLOUD_KEYFILE_JSON" >>  {{ google_credentials_path }}
-      gcloud auth activate-service-account --key-file  {{ google_credentials_path }}
   - id: 'Enable Cloud Run API'
     name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'

--- a/pipeline-modules/deployment-service/gcp/pipeline-config.yaml
+++ b/pipeline-modules/deployment-service/gcp/pipeline-config.yaml
@@ -92,7 +92,7 @@ template: |
       export GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS:-'{{ google_credentials_path }}' }
 
       # write the service-account json to file at GOOGLE_APPLICATION_CREDENTIALS
-      printf '%s' "$$GOOGLE_CLOUD_KEYFILE_JSON" | base64 --decode > $$GOOGLE_APPLICATION_CREDENTIALS
+      printf '%s' "$$GOOGLE_CLOUD_KEYFILE_JSON" > $$GOOGLE_APPLICATION_CREDENTIALS
 
       # activate gcloud cli tools to use GOOGLE_APPLICATION_CREDENTIALS
       gcloud auth activate-service-account --key-file $$GOOGLE_APPLICATION_CREDENTIALS

--- a/pipeline-modules/deployment-service/gcp/pipeline-config.yaml
+++ b/pipeline-modules/deployment-service/gcp/pipeline-config.yaml
@@ -79,8 +79,24 @@ template: |
   {% set workspace = '/workspace' %}   {# has to be a persistent volume #}
   {% set pipeline_env_file = workspace|add:'/.env' %}
   {% set pipeline_modules_path = workspace|add:'/pipeline_modules' %}
+  {% set google_credentials_path = workspace|add:'/codepipes-user-sa.json' %}
 
   steps:
+  - id: 'Switch gcloud auth'
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+    - '-c'
+    - |
+      # make sure GOOGLE_APPLICATION_CREDENTIALS is set
+      export GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS:-'{{ google_credentials_path }}' }
+
+      # write the service-account json to file at GOOGLE_APPLICATION_CREDENTIALS
+      printf '%s' "$$GOOGLE_CLOUD_KEYFILE_JSON" | base64 --decode > $$GOOGLE_APPLICATION_CREDENTIALS
+
+      # activate gcloud cli tools to use GOOGLE_APPLICATION_CREDENTIALS
+      gcloud auth activate-service-account --key-file $$GOOGLE_APPLICATION_CREDENTIALS
+
   - id: 'Init setup'
     name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'


### PR DESCRIPTION
For the app-deployment pipelines, we switch the gcloud CLI to use the user provided service account so that, the pipeline modules gets the access from the given service account rather then relying on the constant cloud build service account.