### PR TITLE
VAN-2096 fix jq setup and make usage consistent

### DIFF
--- a/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
+++ b/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
@@ -166,7 +166,7 @@ template: |
           {% endfor %}
           # aws s3 rm  s3://{{customer_bucket}} --recursive ;
           {% endif %}
-          rm values.yaml;
+          rm -f values.yaml;
 
           echo "applicationName: {{applicationName}} #auto
           environment:  {{environment}} #auto

--- a/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
+++ b/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
@@ -166,7 +166,7 @@ template: |
           {% endfor %}
           # aws s3 rm  s3://{{customer_bucket}} --recursive ;
           {% endif %}
-          rm -f values.yaml;
+          rm values.yaml;
 
           echo "applicationName: {{applicationName}} #auto
           environment:  {{environment}} #auto
@@ -203,8 +203,9 @@ template: |
             tag:  {{ tag }}
             registryCredentials:
               registry: $docker_registry
-              username: $docker_username
-              password: $docker_password" >> values.yaml
+              username: $docker_username" >> values.yaml
+
+          printf '    password: %s\n' "$(printf '%s' "$docker_password" | jq -aRs)" >> values.yaml
 
           echo "
           service:

--- a/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
+++ b/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
@@ -149,7 +149,7 @@ template: |
         - mv linux-amd64/helm /usr/local/bin/helm
     build:
       commands:
-        - export PATH="$PATH:{{workspace}}/bin"
+        - export PATH="{{workspace}}/bin:$PATH"
         - aws eks --region {{region}} update-kubeconfig --name {{cluster}} --role-arn {{roleArn}}
         {% if job_type == 'deploy' %}
         - cd {{helm_chart_path}} ;
@@ -205,7 +205,7 @@ template: |
               registry: $docker_registry
               username: $docker_username" >> values.yaml
 
-          printf '    password: %s\n' "$(printf '%s' "$docker_password" | jq -aRs)" >> values.yaml
+          printf '    password: %s\n' "$(printf '%s' "$docker_password" | jq -aRs .)" >> values.yaml
 
           echo "
           service:

--- a/pipeline-modules/deployment-service/aws/pipeline-config.yaml
+++ b/pipeline-modules/deployment-service/aws/pipeline-config.yaml
@@ -126,7 +126,7 @@ template: |
             - curl -sLJO https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
             - mkdir {{workspace}}/bin && mv jq-linux64 {{workspace}}/bin/jq
             - chmod +x {{workspace}}/bin/jq
-            - export PATH="$PATH:{{workspace}}/bin"
+            - export PATH="{{workspace}}/bin:$PATH"
 
             # Preparing environment variables file...
               {% for env_key, env_value in pipeline_env %}

--- a/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
@@ -163,7 +163,7 @@ template: |
     args:
     - '-c'
     - |
-      export PATH="$$PATH:{{workspace}}/bin";
+      export PATH="{{workspace}}/bin:$$PATH";
       cd {{helm_chart_path}} ;
 
       touch .helmignore;
@@ -214,7 +214,7 @@ template: |
           registry: $$docker_registry
           username: $$docker_username" >> values.yaml
 
-      printf '    password: %s\n' "$(printf '%s' "$docker_password" | jq -aRs)" >> values.yaml
+      printf '    password: %s\n' "$(printf '%s' "$docker_password" | jq -aRs .)" >> values.yaml
 
       echo "
       service:

--- a/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
@@ -178,7 +178,7 @@ template: |
       {% endfor %}
       gsutil rm -r gs://{{customer_bucket}} ;
       {% endif %}
-      rm values.yaml;
+      rm -f values.yaml;
 
       echo "applicationName: {{applicationName}} #auto
       environment:  {{environment}} #auto

--- a/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
@@ -346,7 +346,7 @@ template: |
       {% endfor %}
       gsutil rm -r gs://{{customer_bucket}} ;
       {% endif %}
-      rm values.yaml;
+      rm -f values.yaml;
 
       echo "projectName: {{projectName}}
       applicationName: {{applicationName}} #auto

--- a/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
@@ -331,7 +331,7 @@ template: |
     args:
     - '-c'
     - |
-      export PATH="$$PATH:{{workspace}}/bin";
+      export PATH="{{workspace}}/bin:$$PATH";
       cd {{helm_chart_path}};
 
       touch .helmignore;
@@ -381,7 +381,7 @@ template: |
           registry: $$docker_registry
           username: $$docker_username" >> values.yaml
 
-      printf '    password: %s\n' "$(printf '%s' "$docker_password" | jq -aRs)" >> values.yaml
+      printf '    password: %s\n' "$(printf '%s' "$docker_password" | jq -aRs .)" >> values.yaml
 
       echo "
       {% endif %}

--- a/pipeline-modules/deployment-service/gcp/pipeline-config.yaml
+++ b/pipeline-modules/deployment-service/gcp/pipeline-config.yaml
@@ -107,7 +107,7 @@ template: |
       curl -sLJO https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
       mkdir {{workspace}}/bin && mv jq-linux64 {{workspace}}/bin/jq
       chmod +x {{workspace}}/bin/jq
-      export PATH="$$PATH:{{workspace}}/bin"
+      export PATH="{{workspace}}/bin:$$PATH"
 
       echo "Preparing user environment variables..."
       {% for env_key, env_value in pipeline_env %}


### PR DESCRIPTION
On aws pipelines, jq seems already installed but it was jq 1.5
while we were upgrading it to 1.6 (for consistency)
but the PATH variable was set in a way that the newly installed one
was getting overridden.
So we fix it by overriding the previous one.

Also, the format `jq -aRs` is not backward compatible so changing it to
`jq -aRs .` since that makes it more resilient and consistent
to the other occurrences
