### PR TITLE
VAN-2103 fix required input field rules

### DIFF
--- a/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
+++ b/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
@@ -22,11 +22,11 @@ inputs:
       default: []
       items:
         type: object
+        required: [name]
         properties:
           name:
             title: Service name
             type: string
-            minLength: 1
           containerPort:
             title: Container port
             type: integer

--- a/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
@@ -30,8 +30,6 @@ inputs:
       title: Cluster Name
       description: Cluster name in which deployment will happen
       type: string
-      default: ""
-      minlength: 1
     customer_bucket:
       title: Customer Bucket Name
       description: This is a vanguard Customer  bucket name
@@ -73,6 +71,7 @@ inputs:
       default: []
       items:
         type: object
+        required: [name]
         properties:
           containerPort:
             title: Container port
@@ -84,7 +83,6 @@ inputs:
           name:
             title: Service name
             type: string
-            minlength: 1
           protocol:
             title: Protocol
             type: string
@@ -101,8 +99,6 @@ inputs:
       title: Region name
       description: region name for cluster
       type: string
-      default: ""
-      minlength: 1
     repository:
       title: Container Repository
       description: Enter Full container url without tag

--- a/pipeline-modules/deployment-service/gcp/cloud-run.yaml
+++ b/pipeline-modules/deployment-service/gcp/cloud-run.yaml
@@ -33,8 +33,6 @@ inputs:
       title: Region name
       description: region name for cluster
       type: string
-      default: ""
-      minlength: 1
     repository:
       title: Container Repository
       description: Enter Full container url without tag

--- a/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
@@ -87,8 +87,6 @@ inputs:
       title: Cluster Name
       description: Cluster name in which deployment will happen
       type: string
-      default: ""
-      minlength: 1
     customer_bucket:
       title: Customer Bucket Name
       description: This is a vanguard Customer  bucket name
@@ -145,6 +143,7 @@ inputs:
       default: []
       items:
         type: object
+        required: [name]
         properties:
           containerPort:
             title: Container port
@@ -156,7 +155,6 @@ inputs:
           name:
             title: Service name
             type: string
-            minlength: 1
           protocol:
             title: Protocol
             type: string
@@ -173,8 +171,6 @@ inputs:
       title: Region name
       description: region name for cluster
       type: string
-      default: ""
-      minlength: 1
     repository:
       title: Container Repository
       description: Enter Full container url without tag


### PR DESCRIPTION
change pipeline modules input rule `minlength=1` to `required`
because the input field will not show with required flag otherwise.
althought the validation rule would still work on submit