### PR TITLE
VAN-2156 Fix AWS environment variable handling

### DIFF
--- a/pipeline-modules/deployment-service/aws/pipeline-config.yaml
+++ b/pipeline-modules/deployment-service/aws/pipeline-config.yaml
@@ -119,6 +119,8 @@ template: |
     auth: null
     buildstatusconfig: null
     buildspec: |
+      env:
+        shell: bash
       phases:
         pre_build:
           commands:
@@ -129,8 +131,9 @@ template: |
             - export PATH="{{workspace}}/bin:$PATH"
 
             # Preparing environment variables file...
-            - exported_variable_names=({% for env_key in pipeline_env %} "{{env_key}}" {% endfor %}{% for env_key in pipeline_secret_env %} "{{env_key}}" {% endfor %})
-            - env | while IFS= read -r line; do
+            - |
+              exported_variable_names=({% for env_key in pipeline_env %} "{{env_key}}" {% endfor %}{% for env_key in pipeline_secret_env %} "{{env_key}}" {% endfor %})
+              env | while IFS= read -r line; do
                 name=${line%%=*}
                 re=[[:blank:]]$name[[:blank:]]
                 printf "  $name -> "


### PR DESCRIPTION
Adjustment to previous commit to fix the syntax issue on AWS
related to the expected_variable_names handling. Needed to switch
pipeline from sh to bash as well as setup proper multi-line syntax.
