### PR TITLE
VAN-2203 Add inputArtifactType to meta

### DIFF
--- a/pipeline-modules/deployment-service/aws/test_module.yaml
+++ b/pipeline-modules/deployment-service/aws/test_module.yaml
@@ -8,7 +8,10 @@ target: "test"
 keywords:
   - test
 author: CloudCover
-meta: {}
+meta:
+  inputArtifactType:
+    - git
+
 inputs:
   properties:
     echo_float:

--- a/pipeline-modules/deployment-service/gcp/test_module.yaml
+++ b/pipeline-modules/deployment-service/gcp/test_module.yaml
@@ -8,7 +8,10 @@ target: "test"
 keywords:
   - test
 author: CloudCover
-meta: {}
+meta:
+  inputArtifactType:
+    - git
+
 inputs:
   properties:
     echo_float:


### PR DESCRIPTION
In order to use the test_module, we need it to have an
inputArtifactType. Using a git repo for now.
