### PR TITLE
VAN-2308 Updates to support app-integration testing

### DIFF
--- a/pipeline-modules/app-service/aws/bash.yaml
+++ b/pipeline-modules/app-service/aws/bash.yaml
@@ -1,0 +1,37 @@
+provisioner: aws
+name: bash
+version: 1
+revision: 1
+displayName: Bash script
+description: The bash script to run
+target: ""
+keywords:
+  - bash
+  - linux
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    bash_script:
+      title: Bash script
+      description: This is a bash script
+      type: string
+      default: ""
+    working_dir:
+      title: Working directory
+      description: The current working directory to execute the bash script from
+      type: string
+      default: repo
+  required:
+    - bash_script
+template: |
+  version: 0.2
+  env:
+    shell: bash
+  phases:
+    build:
+      commands:
+        - current_dir=$(pwd)
+        - cd {{ working_dir }}
+        - {{ bash_script }}
+        - cd $current_dir

--- a/pipeline-modules/app-service/aws/docker-build-n-push.yaml
+++ b/pipeline-modules/app-service/aws/docker-build-n-push.yaml
@@ -34,8 +34,9 @@ inputs:
       description: The current working directory to execute command
       type: string
       default: repo
-  required:
+  internal:
     - container_repository
+    - container_tag
 template: |
   version: 0.2
 

--- a/pipeline-modules/app-service/aws/go-build.yaml
+++ b/pipeline-modules/app-service/aws/go-build.yaml
@@ -3,7 +3,7 @@ name: go-build
 version: 1
 revision: 1
 displayName: Go Build
-description: This plugin is for Go builds
+description: Build source code using Golang
 target: ""
 keywords:
   - Go
@@ -25,15 +25,22 @@ inputs:
       description: The current working directory to execute command
       type: string
       default: repo
+    go_version:
+      title: Golang version
+      description: The version of Golang to use
+      type: string
+      default: "1.15.15"
 template: |
   version: 0.2
 
   phases:
-    install:
-      runtime-versions:
-        golang: 1.13
     build:
       commands:
+        - echo Installing Golang v{{ go_version }}
+        - goenv install {{ go_version }}
+        - goenv local {{ go_version }}
+        - CGO_ENABLED=${CGO_ENABLED:-0}
+        - go version
         - echo Building the Go code...
         - cd {{ working_dir }}
         - go build -v {% for arg in go_build_args %} {{ arg }} {% endfor %}

--- a/pipeline-modules/app-service/gcp/docker-build-n-push.yaml
+++ b/pipeline-modules/app-service/gcp/docker-build-n-push.yaml
@@ -34,8 +34,9 @@ inputs:
       description: The current working directory to execute command
       type: string
       default: repo
-  required:
+  internal:
     - container_repository
+    - container_tag
 template: |
   steps:
   - id: 'Docker login'

--- a/pipeline-modules/app-service/gcp/go-build.yaml
+++ b/pipeline-modules/app-service/gcp/go-build.yaml
@@ -3,7 +3,7 @@ name: go-build
 version: 1
 revision: 1
 displayName: Go Build
-description: This plugin is for Go builds
+description: Build source code using Golang
 target: ""
 keywords:
   - Go
@@ -25,12 +25,21 @@ inputs:
       description: The current working directory to execute command
       type: string
       default: repo
+    go_version:
+      title: Golang version
+      description: The version of Golang to use
+      type: string
+      default: latest
 template: |
   steps:
-  - id: 'Go build'
-    name: 'gcr.io/cloud-builders/go'
+  - id: 'Go Version'
+    name: "gcr.io/cloud-builders/go:{{ go_version }}"
+    args: ["version"]
+    env: ["GOPATH=/workspace"]
+  - id: 'Go Build'
+    name: 'gcr.io/cloud-builders/go:{{ go_version }}'
     dir: {{ working_dir }}
-    env: ["GOPATH=/workspace", "PROJECT_ROOT={{ working_dir }}"]
+    env: ["GOPATH=/workspace", "PROJECT_ROOT={{ working_dir }}", "CGO_ENABLED=${CGO_ENABLED:-0}"]
     args:
      - 'build'
      - '-v'


### PR DESCRIPTION
- removed "required" and added "internal" for docker-build-n-push
- Added selection of "go_version" to the go-build module
- Added bash module for AWS
