### PR TITLE
VAN-2255 Load global state to working dir before init

### DIFF
--- a/pipeline-modules/infra-service/aws/pipeline-config.yaml
+++ b/pipeline-modules/infra-service/aws/pipeline-config.yaml
@@ -40,6 +40,11 @@ inputs:
       description: Amount of time in minutes the pipeline will be allowed to run.
       type: integer
       default: 480
+    pipeline_queue_timeout_min:
+      title: Queue Timeout [min]
+      description: Amount of time in minutes the pipeline will be allowed to be queued waiting to run.
+      type: integer
+      default: 480
     pipeline_secret_env:
       title: Global Secret Environment
       description: Mapping of globally available secret variable id.

--- a/pipeline-modules/infra-service/aws/terraform.yaml
+++ b/pipeline-modules/infra-service/aws/terraform.yaml
@@ -146,9 +146,12 @@ template: |
         # replace all '{{ tf_var_name_dash_placeholder }}' placeholders with '-' and quote the value
         # save the result as input variable file for terraform commands
         - printenv | grep "{{ tf_var_name_prefix }}*" | sed 's/^{{ tf_var_name_prefix }}//' | awk -F '=' -v OFS='=' '{ gsub("{{ tf_var_name_dash_placeholder }}", "-", $1); st = index($0,"="); val=substr($0,st+1); print $1, val ~ /^{.*?}$/ || val ~ /^\[.*?\]$/ ? val:"\""val"\"" }' > {{ tf_var_file_path }}
-        # terraform init
         - cd "{{ local_code_path }}"
-        - terraform init > {{ logger('init') }}
+        # terraform state push
+        # push the downloaded global state to the Terraform backend
+        - test ! -f "{{ local_artifact_path }}/{{ tf_state_file }}" || terraform state push {{ local_artifact_path }}/{{ tf_state_file }} > {{ logger('init') }}
+        # terraform init
+        - terraform init >> {{ logger('init') }}
       finally:
         - {{ upload_log_cmd('init') }}
     build:

--- a/pipeline-modules/infra-service/azure/terraform.yaml
+++ b/pipeline-modules/infra-service/azure/terraform.yaml
@@ -151,7 +151,10 @@ template: |
       git checkout "{{ iac_checkout_target }}"
       printenv | grep "{{ tf_var_name_prefix }}*" | sed 's/^{{ tf_var_name_prefix }}//' | awk -F '=' -v OFS='=' '{ gsub("{{ tf_var_name_dash_placeholder }}", "-", $1); st = index($0,"="); val=substr($0,st+1); print $1, val ~ /^{.*?}$/ || val ~ /^\[.*?\]$/ ? val:"\""val"\"" }' > {{ tf_var_file_path }}
       cd "{{ local_code_path }}"
-      terraform init
+      # terraform state push
+      test ! -f "{{ local_artifact_path }}/{{ tf_state_file }}" || terraform state push {{ local_artifact_path }}/{{ tf_state_file }} > {{ logger('init') }}
+      # terraform init
+      terraform init >> {{ logger('init') }}
       az login --service-principal -u $(ARM_CLIENT_ID) -p $(ARM_CLIENT_SECRET) -t $(ARM_TENANT_ID)
       az account set --subscription $(ARM_SUBSCRIPTION_ID)
       {% if tf_action == 'plan' %}

--- a/pipeline-modules/infra-service/gcp/pipeline-config.yaml
+++ b/pipeline-modules/infra-service/gcp/pipeline-config.yaml
@@ -62,12 +62,18 @@ inputs:
       description: Amount of time in seconds the pipeline will be allowed to run.
       type: integer
       default: 4000
+    pipeline_queue_timeout_sec:
+      title: Queue Timeout [s]
+      description: Amount of time in seconds the pipeline will be allowed to be queued waiting to run.
+      type: integer
+      default: 7200
   internal:
     - pipeline_env
     - pipeline_secret_env
     - pipeline_secret_env_key
 template: |
   timeout: {{ pipeline_timeout_sec }}s
+  queueTtl: {{ pipeline_queue_timeout_sec }}s
   {% if pipeline_logs_bucket %}logsBucket: 'gs://{{ pipeline_logs_bucket }}'{% endif %}
   tags:
   {% for tag in pipeline_tags %}

--- a/pipeline-modules/infra-service/gcp/terraform.yaml
+++ b/pipeline-modules/infra-service/gcp/terraform.yaml
@@ -182,12 +182,19 @@ template: |
     args:
       - -c
       - printenv | grep "{{ tf_var_name_prefix }}*" | sed 's/^{{ tf_var_name_prefix }}//' | awk -F '=' -v OFS='=' '{ gsub("{{ tf_var_name_dash_placeholder }}", "-", $1); st = index($0,"="); val=substr($0,st+1); print $1, val ~ /^{.*?}$/ || val ~ /^\[.*?\]$/ ? val:"\""val"\"" }' > {{ tf_var_file_path }}
+  - id: 'terraform state push'
+    name: 'hashicorp/terraform:{{ tf_version }}'
+    entrypoint: sh
+    args:
+      - -c
+      - 'test ! -f "{{ local_artifact_path }}/{{ tf_state_file }}" || terraform state push {{ local_artifact_path }}/{{ tf_state_file }} > {{ logger('init') }} || {{ set_fail_flag('terraform init') }}'
+    dir: {{ local_code_path }}
   - id: 'terraform init'
     name: 'hashicorp/terraform:{{ tf_version }}'
     entrypoint: sh
     args:
       - -c
-      - 'terraform init > {{ logger('init') }} || {{ set_fail_flag('terraform init') }}'
+      - 'terraform init >> {{ logger('init') }} || {{ set_fail_flag('terraform init') }}'
     dir: {{ local_code_path }}
   {{ upload_log('init') }}
   {{ fail_on_flag() }}


### PR DESCRIPTION
The state file must be in the code directory before init.
In order to maintain all artifacts together
use 'terraform state push' command to copy the state to
the backend (working dir) before init.
This command may also work better (compared to straight 'cp')
with different backends.

Also add missing pipeline queue timeout parameters.