### PR TITLE
VAN-2366 Add support for Azure appint to Opstest

### DIFF
--- a/pipeline-modules/app-service/azure/bash.yaml
+++ b/pipeline-modules/app-service/azure/bash.yaml
@@ -1,0 +1,35 @@
+provisioner: azure
+name: bash
+version: 1
+revision: 1
+displayName: Bash script
+description: Execute a bash script
+target: ""
+keywords:
+  - bash
+  - linux
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    bash_script:
+      title: Bash script
+      description: This is a bash script
+      type: string
+      default: ""
+    working_dir:
+      title: Working directory
+      description: The current working directory to execute the bash script from
+      type: string
+      default: repo
+  required:
+    - bash_script
+template: |
+  steps:
+  - task: Bash@3
+    inputs:
+      targetType: inline
+      working_dir: {{ working_dir }}
+      script: |
+        set -x
+        {{ bash_script }}

--- a/pipeline-modules/app-service/azure/git-access.yaml
+++ b/pipeline-modules/app-service/azure/git-access.yaml
@@ -1,0 +1,40 @@
+provisioner: azure
+name: git-access
+version: 1
+revision: 1
+displayName: Git access
+description: Configure access to a remote Git repository.
+target: ""
+keywords:
+  - git
+  - access
+  - credentials
+  - auth
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    git_login:
+      title: Login
+      description: Git login.
+      type: string
+    git_remote_path:
+      title: Repository URL
+      description: The repository to configure access to.
+      type: string
+  required:
+    - git_remote_path
+    - git_login
+  internal:
+    - git_remote_path
+    - git_login
+template: |
+  {% set git_creds_path = '$(System.DefaultWorkingDirectory)/.git-credentials' %}
+  {% set git_config_path = '$(System.DefaultWorkingDirectory)/.gitconfig' %}
+  steps:
+  - script: |
+      git config --file {{ git_config_path }} credential.helper 'store --file {{ git_creds_path }}'
+      git config --file {{ git_config_path }} credential.useHttpPath true
+      git config --file {{ git_config_path }} credential.interactive never
+      git config --global url."https://{{ git_login }}:$(GIT_PASSWORD)@github.com/".insteadOf "https://github.com/"
+      echo "https://{{ git_login }}:$(GIT_PASSWORD)@{{ git_remote_path }}" >> {{ git_creds_path }}

--- a/pipeline-modules/app-service/azure/git-clone.yaml
+++ b/pipeline-modules/app-service/azure/git-clone.yaml
@@ -1,0 +1,36 @@
+provisioner: azure
+name: git-clone
+version: 1
+revision: 1
+displayName: Git clone
+description: Clone remote Git repository and checkout a given commit if specified.
+target: ""
+keywords:
+  - git
+  - clone
+  - checkout
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    git_checkout_target:
+      title: Checkout Target
+      description: Git branch, tag or commit hash to checkout.
+      type: string
+      default: ""
+    git_local_path:
+      title: Local Clone Directory
+      description: The name of a new directory to clone into.
+      type: string
+      default: repo
+    git_remote_path:
+      title: Repository URL
+      description: The repository to clone from.
+      type: string
+  required:
+    - git_remote_path
+template: |
+  steps:
+  - script: |
+      git clone {% if git_checkout_target %}--no-checkout{% endif %} https://{{ git_remote_path }} {{ git_local_path }}{% if git_checkout_target %}
+      cd {{ git_local_path }} && git checkout {{ git_checkout_target }} && cd .. {% endif %}

--- a/pipeline-modules/app-service/azure/pipeline-config.yaml
+++ b/pipeline-modules/app-service/azure/pipeline-config.yaml
@@ -1,0 +1,63 @@
+provisioner: azure
+name: pipeline-config
+version: 1
+revision: 1
+displayName: Configure Pipeline
+description: Configure global pipeline options and environment.
+target: config
+keywords:
+  - env
+  - environment
+  - secret
+  - config
+  - configuration
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    variable_group_name:
+      title: Secret Variables Group
+      description: Keeps all secret variables available to pipeline.
+      type: string
+      default: ""
+    pipeline_env:
+      title: Global Environment
+      description: Mapping of globally available variables to values.
+      type: object
+      default: {}
+    pipeline_secret_env:
+      title: Global Secret Environment
+      description: Mapping of globally available variables to encrypted values.
+      type: object
+      default: {}
+    pipeline_secret_env_key:
+      title: Secret Environment Encryption Key
+      description: Name of a KMS key used to encrypt secret values.
+      type: string
+      default: ""
+  required:
+    - variable_group_name
+  internal:
+    - variable_group_name
+    - pipeline_env
+    - pipeline_secret_env
+    - pipeline_secret_env_key
+template: |
+  {% set workspace = '$BUILD_SOURCESDIRECTORY' %}   {# has to be a persistent volume #}
+  {% set pipeline_env_file = workspace|add:'/.env' %}
+
+  name: '$(Date:yyyyMMdd)$(Rev:.r)'
+  steps:
+  - script: |
+      {% for env_key in pipeline_env %}
+      export {{env_key}}="$({{env_key}})"
+      printf "{{env_key}}=%s\n" "$(printf "%s" "${{env_key}}" | jq -aRs .)" >> {{pipeline_env_file}}
+      {%- endfor %}
+
+      {% for env_key in pipeline_secret_env %}
+      export {{env_key}}="$({{env_key}})"
+      printf "{{env_key}}=%s\n" "$(printf "%s" "${{env_key}}" | jq -aRs .)" >> {{pipeline_env_file}}
+      {%- endfor %}
+
+  variables:
+    - group: {{ variable_group_name }}

--- a/pipeline-modules/app-service/azure/test_module.yaml
+++ b/pipeline-modules/app-service/azure/test_module.yaml
@@ -1,4 +1,4 @@
-provisioner: gcp
+provisioner: azure
 name: test_module
 version: 1
 revision: 1
@@ -36,34 +36,17 @@ inputs:
       title: Echo String value
       description: The string to echo to the log.
       type: string
-    pipeline_summary_var:
-      title: Pipeline Summary
-      description: This will create pipeline summary as per user request
-      type: array
-      default: []
-      items:
-        type: object
-        properties:
-          Command:
-            title: Command
-            type: string
-          Name:
-            title: Name
-            type: string
   required:
     - echo_string
     - echo_int
     - echo_float
     - echo_map
     - echo_list
-  internal:
-    - pipeline_summary_var
 template: |
   steps:
-  - name: 'bash'
-    args:
-    - '-c'
-    - |-
+  - script: |
+      cat .env
+      source .env
       echo "stringVal={{ echo_string }}"
       echo "intVal={{ echo_int }}"
       echo "floatVal={{ echo_float }}"
@@ -75,15 +58,3 @@ template: |
       {% for list_value in echo_list %}
       echo "    {{ list_value }}"
       {% endfor %}
-  - name: 'bash'
-    args:
-    - '-c'
-    - |
-      echo "###pipeline-summary-start###" >> summary.txt 2>&1;
-      {% if pipeline_summary_var %}
-      {% for summary in pipeline_summary_var %}
-      {{ summary.Command }} | xargs -0 printf "{{ summary.Name }}=%s\n" >>  summary.txt 2>&1; {% endfor %}
-      {% endif %}
-      echo "Service URL=[test_module succeeded $(date)]" >> summary.txt 2>&1;
-      echo "###pipeline-summary-end###" >> summary.txt 2>&1;
-      cat summary.txt;

--- a/pipeline-modules/deployment-service/aws/test_module.yaml
+++ b/pipeline-modules/deployment-service/aws/test_module.yaml
@@ -10,7 +10,7 @@ keywords:
 author: CloudCover
 meta:
   inputArtifactType:
-    - git
+    - container
 
 inputs:
   properties:
@@ -62,3 +62,13 @@ template: |
         {% for list_value in echo_list %}
         - echo "    {{ list_value }}"
         {% endfor %}
+    post_build:
+      commands:
+        - echo "###pipeline-summary-start###" >> summary.txt 2>&1
+        {% if pipeline_summary_var %}
+        - {% for summary in pipeline_summary_var %} {{ summary.Command }} | xargs -0 printf "{{ summary.Name }}=%s\n" >>  summary.txt 2>&1; {% endfor %}
+        {% endif %}
+        - echo "###pipeline-summary-start###" >> summary.txt 2>&1
+        - echo "Service URL=[test_module succeeded $(date)]" >> summary.txt 2>&1
+        - echo "###pipeline-summary-end###" >> summary.txt 2>&1
+        - cat summary.txt

--- a/pipeline-modules/deployment-service/azure/test_module.yaml
+++ b/pipeline-modules/deployment-service/azure/test_module.yaml
@@ -10,7 +10,7 @@ keywords:
 author: CloudCover
 meta:
   inputArtifactType:
-    - git
+    - container
 
 inputs:
   properties:
@@ -56,3 +56,12 @@ template: |
       {% for list_value in echo_list %}
       echo "    {{ list_value }}"
       {% endfor %}
+  - script: |
+      echo "###pipeline-summary-start###" >> summary.txt 2>&1
+      {% if pipeline_summary_var %}
+      {% for summary in pipeline_summary_var %}
+      {{ summary.Command }} | xargs -0 printf "{{ summary.Name }}=%s\n" >>  summary.txt 2>&1 {% endfor %}
+      {% endif %}
+      echo "Service URL=[test_module succeeded: $(date)]" >> summary.txt 2>&1
+      echo "###pipeline-summary-end###" >> summary.txt 2>&1
+      cat summary.txt


### PR DESCRIPTION
    - Add required modules for azure app integration:
      git-access, git-clone, pipeline-config
    - Add the test_module used by the Opstest scenario
    - Change the artifact type for test_module to container
    Additional unrelated fix:
    - Add pipeline summary function to deployment test_module