### PR TITLE
VAN-2310 Add TF destroy for Azure and fix plan

### DIFF
--- a/pipeline-modules/infra-service/aws/terraform.yaml
+++ b/pipeline-modules/infra-service/aws/terraform.yaml
@@ -39,6 +39,7 @@ inputs:
       type: string
       enum:
         - plan
+        - plan-destroy
         - apply
         - destroy
     tf_plan_file:
@@ -156,9 +157,9 @@ template: |
         - {{ upload_log_cmd('init') }}
     build:
       commands:
-      {% if tf_action == 'plan' %}
+      {% if tf_action == 'plan' || tf_action == 'plan-destroy' %}
         # terraform plan
-        - terraform plan -var-file={{ tf_var_file_path }} {% if tf_action == 'destroy' %}-destroy{% endif %} -out={{ local_artifact_path }}/{{ tf_plan_file }} -state={{ local_artifact_path }}/{{ tf_state_file }} > {{ logger('plan') }}
+        - terraform plan -var-file={{ tf_var_file_path }} {% if tf_action == 'plan-destroy' %}-destroy{% endif %} -out={{ local_artifact_path }}/{{ tf_plan_file }} -state={{ local_artifact_path }}/{{ tf_state_file }} > {{ logger('plan') }}
         # terraform show
         - terraform show -json {{ local_artifact_path }}/{{ tf_plan_file }} 1> {{ local_artifact_path }}/{{ tf_plan_json_file }} 2>> {{ logger('plan', false) }}
       finally:

--- a/pipeline-modules/infra-service/azure/terraform.yaml
+++ b/pipeline-modules/infra-service/azure/terraform.yaml
@@ -53,6 +53,7 @@ inputs:
       type: string
       enum:
         - plan
+        - plan-destroy
         - apply
         - destroy
     tf_plan_file:
@@ -160,9 +161,9 @@ template: |
       az login --service-principal -u $(ARM_CLIENT_ID) -p $(ARM_CLIENT_SECRET) -t $(ARM_TENANT_ID)
       az account set --subscription $(ARM_SUBSCRIPTION_ID)
       {{ upload_log('init') }}
-      {% if tf_action == 'plan' %}
+      {% if tf_action == 'plan' || tf_action == 'plan-destroy' %}
       # terraform plan
-      terraform plan -var-file={{ tf_var_file_path }} -out={{ local_artifact_path }}/{{ tf_plan_file }} -state={{ local_artifact_path }}/{{ tf_state_file }} > {{ logger('plan') }}
+      terraform plan -var-file={{ tf_var_file_path }} {% if tf_action == 'plan-destroy' %}-destroy{% endif %} -out={{ local_artifact_path }}/{{ tf_plan_file }} -state={{ local_artifact_path }}/{{ tf_state_file }} > {{ logger('plan') }}
       # terraform show
       terraform show -json {{ local_artifact_path }}/{{ tf_plan_file }} 1> {{ local_artifact_path }}/{{ tf_plan_json_file }} 2>> {{ logger('plan', false) }}
       {{ upload_log('plan') }}
@@ -170,8 +171,14 @@ template: |
       {{ upload_artifact(tf_plan_json_file) }}
       {% elif tf_action == 'apply' %}
       {{ download_artifact(tf_plan_file) }}
+      # terraform apply
       terraform apply -auto-approve -backup=- -state={{ local_artifact_path }}/{{ tf_state_file }} {{ local_artifact_path }}/{{ tf_plan_file }} > {{ logger('apply') }}
       {{ upload_log('apply') }}
       {{ upload_artifact(tf_state_file) }}
+      {% elif tf_action == 'destroy' %}
+      # terraform destroy
+      terraform destroy -var-file={{ tf_var_file_path }} -auto-approve -backup=- -state={{ local_artifact_path }}/{{ tf_state_file }} > {{ logger('destroy') }}
+      {{ upload_log('destroy') }}
+      {{ upload_artifact(tf_state_file) }}  {# upload the state even if the TF action failed as it may have already been modified #}
       {% endif %}
       az logout

--- a/pipeline-modules/infra-service/gcp/terraform.yaml
+++ b/pipeline-modules/infra-service/gcp/terraform.yaml
@@ -39,6 +39,7 @@ inputs:
       type: string
       enum:
         - plan
+        - plan-destroy
         - apply
         - destroy
     tf_plan_file:
@@ -198,13 +199,13 @@ template: |
     dir: {{ local_code_path }}
   {{ upload_log('init') }}
   {{ fail_on_flag() }}
-  {% if tf_action == 'plan' %}
+  {% if tf_action == 'plan' || tf_action == 'plan-destroy' %}
   - id: 'terraform plan'
     name: 'hashicorp/terraform:{{ tf_version }}'
     entrypoint: sh
     args:
       - -c
-      - 'terraform plan -var-file={{ tf_var_file_path }} {% if tf_action == 'destroy' %}-destroy{% endif %} -out={{ local_artifact_path }}/{{ tf_plan_file }} -state={{ local_artifact_path }}/{{ tf_state_file }} > {{ logger('plan') }} || {{ set_fail_flag('terraform plan') }}'
+      - 'terraform plan -var-file={{ tf_var_file_path }} {% if tf_action == 'plan-destroy' %}-destroy{% endif %} -out={{ local_artifact_path }}/{{ tf_plan_file }} -state={{ local_artifact_path }}/{{ tf_state_file }} > {{ logger('plan') }} || {{ set_fail_flag('terraform plan') }}'
     dir: {{ local_code_path }}
   - id: 'terraform show'
     name: 'hashicorp/terraform:{{ tf_version }}'


### PR DESCRIPTION
Add Terraform destroy operation to Azure module.

Also fix plan generation in all modules.

In order to generate destroy plan one must provide '-destroy'
option to plan command.

"This will run terraform plan in destroy mode,
showing you the proposed destroy changes without executing them."

Previous code was attempting to do that but because of the 'tf_action'
value only apply plan would be generated (this would not affect destroy
itself as that does not use plan file).

This patch adds new 'plan-destroy' action that generates destroy plan.