### PR TITLE
VAN-2454 added input=false flag for terraform

### DIFF
--- a/pipeline-modules/deployment-service/azure/basic-aks-module.yaml
+++ b/pipeline-modules/deployment-service/azure/basic-aks-module.yaml
@@ -258,7 +258,6 @@ template: |
             helm upgrade --install -f values.yaml {{applicationName}}-{{environment}} . --atomic --timeout {{deployment_timeout}}
       displayName: "Helm Deploy {{applicationName}}"
       workingDirectory: {{ workingDir }}
-    {% if pipeline_summary_var %}
     - script: |
             summary_command=$(kubectl get svc -n {{applicationName}} -o=jsonpath={.items[*].status.loadBalancer.ingress[*].ip})
             cat <<EOF >>summary.txt
@@ -276,4 +275,3 @@ template: |
             cat summary.txt
       displayName: "Pipeline Summary for {{applicationName}}"
       workingDirectory: {{ workingDir }}
-    {% endif %}

--- a/pipeline-modules/deployment-service/azure/basic-aks-module.yaml
+++ b/pipeline-modules/deployment-service/azure/basic-aks-module.yaml
@@ -258,6 +258,7 @@ template: |
             helm upgrade --install -f values.yaml {{applicationName}}-{{environment}} . --atomic --timeout {{deployment_timeout}}
       displayName: "Helm Deploy {{applicationName}}"
       workingDirectory: {{ workingDir }}
+    {% if ports %}
     - script: |
             summary_command=$(kubectl get svc -n {{applicationName}} -o=jsonpath={.items[*].status.loadBalancer.ingress[*].ip})
             cat <<EOF >>summary.txt
@@ -275,3 +276,4 @@ template: |
             cat summary.txt
       displayName: "Pipeline Summary for {{applicationName}}"
       workingDirectory: {{ workingDir }}
+      {% endif %}

--- a/pipeline-modules/infra-service/azure/terraform.yaml
+++ b/pipeline-modules/infra-service/azure/terraform.yaml
@@ -82,7 +82,7 @@ inputs:
         - WARN
         - ERROR
         - JSON
-      default: ERROR
+      default: DEBUG
   required:
     - iac_checkout_src
     - iac_checkout_target

--- a/pipeline-modules/infra-service/azure/terraform.yaml
+++ b/pipeline-modules/infra-service/azure/terraform.yaml
@@ -82,7 +82,7 @@ inputs:
         - WARN
         - ERROR
         - JSON
-      default: DEBUG
+      default: ERROR
   required:
     - iac_checkout_src
     - iac_checkout_target
@@ -135,6 +135,11 @@ template: |
   {% macro download_artifact(file, ignore_err=false) -%}
   az storage blob download --name "{{ artifact_root_path }}/{{ file }}" --file "{{ local_artifact_path }}/{{ file }}" --account-name {{storage_account_name}} --auth-mode login --container-name {{artifact_bucket}}
   {%- endmacro %}
+
+  variables:
+    TF_IN_AUTOMATION: 'true'
+    TF_INPUT: 'false'
+    TF_LOG: '{{ tf_log_level }}'
 
   steps:
   - task: ms-devlabs.custom-terraform-tasks.custom-terraform-installer-task.TerraformInstaller@0


### PR DESCRIPTION
Added -input=false parameter on pipelines so that if a required the input is not provided terraform does not keep waiting for input and fails immediately.