### PR TITLE
VAN-2485 Add Integration Modules (sonar and java-unit-test)

### DIFF
--- a/pipeline-modules/app-service/aws/git-clone.yaml
+++ b/pipeline-modules/app-service/aws/git-clone.yaml
@@ -27,12 +27,18 @@ inputs:
       title: Repository URL
       description: The repository to clone from.
       type: string
-  required:
+    working_dir:
+      title: Working directory
+      description: The current working directory to execute command
+      type: string
+      default: repo
+  internal:
     - git_remote_path
+    - working_dir
 template: |
   version: 0.2
   phases:
     pre_build:
       commands:
         - git clone {% if git_checkout_target %}--no-checkout{% endif %} https://{{ git_remote_path }} {{ git_local_path }}{% if git_checkout_target %}
-        - cd {{ git_local_path }} && git checkout {{ git_checkout_target }} && cd .. {% endif %}
+        - cd {{ git_local_path }} && git checkout {{ git_checkout_target }} && cd .. {% endif %} && cd {{working_dir}}

--- a/pipeline-modules/app-service/aws/java-unit-test.yaml
+++ b/pipeline-modules/app-service/aws/java-unit-test.yaml
@@ -1,0 +1,36 @@
+provisioner: aws
+name: java-unit-test
+version: 1
+revision: 1
+displayName: Java UnitTest with Maven
+description: run Java unit test with Maven
+target: ""
+keywords:
+  - java
+  - unit-test
+  - maven
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    working_dir:
+      title: Working directory
+      description: The current working directory to execute command
+      type: string
+      default: repo
+    test_args:
+      title: Mvn test command arguments
+      description: Arguments for mvn test command
+      type: array
+      default: []
+      items:
+        type: string
+  internal:
+  - working_dir
+template: |
+  version: 0.2
+  phases:
+    build:
+      commands:
+        - echo Running unit test..
+        - mvn test {% for arg in test_args %} {{ arg }} {% endfor %}

--- a/pipeline-modules/app-service/aws/sonar-mvn.yaml
+++ b/pipeline-modules/app-service/aws/sonar-mvn.yaml
@@ -1,0 +1,63 @@
+provisioner: aws
+name: sonar-mvn
+version: 1
+revision: 1
+displayName: Sonar maven
+description: Analyze java source code using SonarCloud/SonarQube
+target: ""
+keywords:
+  - Analyze Code
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    git_local_path:
+      title: Local Clone Directory
+      description: The name of a new directory to clone into.
+      type: string
+      default: repo
+    sonar_host:
+      title: Host IP
+      description: IP where sonarqube is hosted, for sonarcloud it will be https://sonarcloud.io
+      type: string
+    sonar_cloud_org:
+      title: Sonar Organization Key
+      description: Sonar organization key found in project information section of sonar cloud web console
+      type: string
+    sonar_cloud_project_key:
+      title: Sonar Project Key
+      description: Sonar project key found in project information section of sonar cloud web console. This is required if sonar_config_file is not set
+      type: string
+    sonar_login_token:
+      title: Sonar login token
+      description: Personal access token for sonar, can be gerenrated from <host>/account/security/
+      type: string
+    sonar_config_file:
+      title: Sonar config file name
+      description: Optionally, use a config file in the repo to setup sonar properties
+      type: string
+  required:
+    - sonar_host
+    - sonar_cloud_org
+    - sonar_cloud_project_key
+    - sonar_login_token
+template: |
+  version: 0.2
+  phases:
+    install:
+      commands:
+        - apt-get update
+        - apt-get install -y jq
+        - wget http://www-eu.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
+        - tar xzf apache-maven-3.5.4-bin.tar.gz
+        - ln -s apache-maven-3.5.4 maven
+        - wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.3.0.1492-linux.zip
+        - unzip ./sonar-scanner-cli-3.3.0.1492-linux.zip
+        - export PATH=$PATH:/sonar-scanner-3.3.0.1492-linux/bin/
+    build:
+      commands:
+        - mvn sonar:sonar -Dsonar.login={{sonar_login_token}} -Dsonar.host.url={{sonar_host}} -Dsonar.projectKey={{sonar_cloud_project_key}} -Dsonar.organization={{sonar_cloud_org}}
+        - sleep 5
+        - curl https://sonarcloud.io/api/qualitygates/project_status?projectKey={{sonar_cloud_project_key}} >result.json
+        - cat result.json
+        - if [ $(jq -r '.projectStatus.status' result.json) = ERROR ] ; then $CODEBUILD_BUILD_SUCCEEDING -eq 0 ;fi


### PR DESCRIPTION
Added sonarCloud and sonarQube implementation
Added unit test template for java using maven
Updated path change to git clone, to access working directory for subsequent templates

PS: I have kept the version pinned for sonar and maven because their mvn:sonar was working with another version of sonar and maven. need to improve sonar template to work without maven plugin [VAN-2502](https://cldcvr.atlassian.net/browse/VAN-2502)