### PR TITLE
VAN-2635 Change type of containerPort to integer

### DIFF
--- a/pipeline-modules/deployment-service/gcp/cloud-run.yaml
+++ b/pipeline-modules/deployment-service/gcp/cloud-run.yaml
@@ -51,7 +51,7 @@ inputs:
     containerPort:
       title: Container Port
       description: Requests will be sent to the container on this port, default is 8080
-      type: string
+      type: integer
       default: 8080
     job_type:
       title: Job Type


### PR DESCRIPTION
The default value is being specified as an integer but the input
is declared as a string. For consistency with other places we have
ports defined, switching to integer.
