### PR TITLE
VAN-2748 Copy TF state instead of using push

### DIFF
--- a/pipeline-modules/infra-service/aws/terraform.yaml
+++ b/pipeline-modules/infra-service/aws/terraform.yaml
@@ -153,9 +153,8 @@ template: |
         - cd "{{ local_code_path }}"
         # run a pre script for user if user
         - if [ -f {{user_pre_script}} ] ; then chmod +x {{user_pre_script}} && ./{{user_pre_script}} ; fi
-        # terraform state push
-        # push the downloaded global state to the Terraform backend
-        - test ! -f "{{ local_artifact_path }}/{{ tf_state_file }}" || terraform state push {{ local_artifact_path }}/{{ tf_state_file }} > {{ logger('init') }}
+        # copy pre-existing terraform state to the working directory
+        - test ! -f "{{ local_artifact_path }}/{{ tf_state_file }}" || cp -f -v {{ local_artifact_path }}/{{ tf_state_file }} {{ local_code_path }}/{{ tf_state_file }} > {{ logger('init') }}
         # terraform init
         - terraform init >> {{ logger('init') }}
       finally:

--- a/pipeline-modules/infra-service/azure/terraform.yaml
+++ b/pipeline-modules/infra-service/azure/terraform.yaml
@@ -166,8 +166,8 @@ template: |
       find . -name "cp_components*.tf" -maxdepth 1 -type f -exec cp -f "{}" "{{ local_code_path }}" \;
       printenv | grep "{{ tf_var_name_prefix }}*" | sed 's/^{{ tf_var_name_prefix }}//' | awk -F '=' -v OFS='=' '{ gsub("{{ tf_var_name_dash_placeholder }}", "-", $1); st = index($0,"="); val=substr($0,st+1); print $1, val ~ /^{.*?}$/ || val ~ /^\[.*?\]$/ ? val:"\""val"\"" }' > {{ tf_var_file_path }}
       cd "{{ local_code_path }}"
-      # terraform state push
-      test ! -f "{{ local_artifact_path }}/{{ tf_state_file }}" || terraform state push {{ local_artifact_path }}/{{ tf_state_file }} > {{ logger('init') }}
+      # copy pre-existing terraform state to the working directory
+      test ! -f "{{ local_artifact_path }}/{{ tf_state_file }}" || cp -f -v {{ local_artifact_path }}/{{ tf_state_file }} {{ local_code_path }}/{{ tf_state_file }} > {{ logger('init') }}
       # terraform init
       terraform init >> {{ logger('init') }}
       az account set --subscription $(ARM_SUBSCRIPTION_ID)

--- a/pipeline-modules/infra-service/gcp/terraform.yaml
+++ b/pipeline-modules/infra-service/gcp/terraform.yaml
@@ -189,12 +189,12 @@ template: |
     args:
       - -c
       - printenv | grep "{{ tf_var_name_prefix }}*" | sed 's/^{{ tf_var_name_prefix }}//' | awk -F '=' -v OFS='=' '{ gsub("{{ tf_var_name_dash_placeholder }}", "-", $1); st = index($0,"="); val=substr($0,st+1); print $1, val ~ /^{.*?}$/ || val ~ /^\[.*?\]$/ ? val:"\""val"\"" }' > {{ tf_var_file_path }}
-  - id: 'terraform state push'
-    name: 'hashicorp/terraform:{{ tf_version }}'
+  - id: 'copy current terraform state'
+    name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: sh
     args:
       - -c
-      - 'test ! -f "{{ local_artifact_path }}/{{ tf_state_file }}" || terraform state push {{ local_artifact_path }}/{{ tf_state_file }} > {{ logger('init') }} || {{ set_fail_flag('terraform init') }}'
+      - 'test ! -f "{{ local_artifact_path }}/{{ tf_state_file }}" || cp -f -v {{ local_artifact_path }}/{{ tf_state_file }} {{ local_code_path }}/{{ tf_state_file }} > {{ logger('init') }} || {{ set_fail_flag('terraform init') }}'
     dir: {{ local_code_path }}
   - id: 'terraform init'
     name: 'hashicorp/terraform:{{ tf_version }}'


### PR DESCRIPTION
Terraform state must be present in the working directory
before running init. It must be called terraform.tfstate.

We used terraform push command to achieve this. This
command is primarily for working with remote backends.
It performs additional checks.

Unfortunatelly it fails on TF >= 1.2.0
It requires init to be done first.
This is not compatible with our use to initialize the working
directory before init.

Since we do not really require the push as we managed the state
ourselves we can instead just copy the state file to the working directoy
to achieve the same result.