### PR TITLE
VAN-2920 Mark component exports as sensitive

### DIFF
--- a/pipeline-modules/infra-service/aws/component.yaml
+++ b/pipeline-modules/infra-service/aws/component.yaml
@@ -129,6 +129,7 @@ template: |
                     output "{{ component.label }}_{{ output.name }}" {
                     {% if not output.expression %}
                     value = module.{{ component.label }}[*].{{ output.name }}
+                    sensitive = true
                     {% else %}
                     value = {{ output.expression }}
                     {% endif %}

--- a/pipeline-modules/infra-service/azure/component.yaml
+++ b/pipeline-modules/infra-service/azure/component.yaml
@@ -126,6 +126,7 @@ template: |
         output "{{ component.label }}_{{ output.name }}" {
         {% if not output.expression %}
         value = module.{{ component.label }}[*].{{ output.name }}
+        sensitive = true
         {% else %}
         value = {{ output.expression }}
         {% endif %}

--- a/pipeline-modules/infra-service/gcp/component.yaml
+++ b/pipeline-modules/infra-service/gcp/component.yaml
@@ -131,6 +131,7 @@ template: |
                 output "{{ component.label }}_{{ output.name }}" {
                 {% if not output.expression %}
                 value = module.{{ component.label }}[*].{{ output.name }}
+                sensitive = true
                 {% else %}
                 value = {{ output.expression }}
                 {% endif %}


### PR DESCRIPTION
Declare all component outputs as sensitive in Terraform.
This is to make the exported outputs compatible with
sensitive module outputs.
This does not affect how they are stored in the state.
Older Terraform versions ignore the senitive attribute.