### PR TITLE
VAN-2924 Added -upgrade flag to update lock file if there is a version change

### DIFF
--- a/pipeline-modules/infra-service/aws/terraform.yaml
+++ b/pipeline-modules/infra-service/aws/terraform.yaml
@@ -156,7 +156,7 @@ template: |
         # copy pre-existing terraform state to the working directory
         - test ! -f "{{ local_artifact_path }}/{{ tf_state_file }}" || cp -f -v {{ local_artifact_path }}/{{ tf_state_file }} {{ local_code_path }}/{{ tf_state_file }} > {{ logger('init') }}
         # terraform init
-        - terraform init >> {{ logger('init') }}
+        - terraform init -upgrade >> {{ logger('init') }}
       finally:
         - {{ upload_log_cmd('init') }}
     build:

--- a/pipeline-modules/infra-service/azure/terraform.yaml
+++ b/pipeline-modules/infra-service/azure/terraform.yaml
@@ -168,8 +168,8 @@ template: |
       cd "{{ local_code_path }}"
       # copy pre-existing terraform state to the working directory
       test ! -f "{{ local_artifact_path }}/{{ tf_state_file }}" || cp -f -v {{ local_artifact_path }}/{{ tf_state_file }} {{ local_code_path }}/{{ tf_state_file }} > {{ logger('init') }}
-      # terraform init
-      terraform init >> {{ logger('init') }}
+      # terraform init -upgrade
+      terraform init -upgrade >> {{ logger('init') }}
       az account set --subscription $(ARM_SUBSCRIPTION_ID)
       {{ upload_log('init') }}
       {% if tf_action == 'plan' || tf_action == 'plan-destroy' %}

--- a/pipeline-modules/infra-service/gcp/terraform.yaml
+++ b/pipeline-modules/infra-service/gcp/terraform.yaml
@@ -201,7 +201,7 @@ template: |
     entrypoint: sh
     args:
       - -c
-      - 'terraform init >> {{ logger('init') }} || {{ set_fail_flag('terraform init') }}'
+      - 'terraform init -upgrade >> {{ logger('init') }} || {{ set_fail_flag('terraform init') }}'
     dir: {{ local_code_path }}
   {{ upload_log('init') }}
   {{ fail_on_flag() }}


### PR DESCRIPTION
Without Init Upgrade, when the terraform, versions are upgraded, terraform doesn’t update them in lock file and gives error. Hence need to add -upgrade so that if there is an upgrade, Terraform will automatically update it.