### PR TITLE
VAN-2953 | Upgrade GKE Cluster API version

### DIFF
--- a/helm/gcp/basic-gke/templates/ingress.yaml
+++ b/helm/gcp/basic-gke/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.applicationName }}-ingress

--- a/helm/gcp/istio-gke/templates/gke-ingress.yaml
+++ b/helm/gcp/istio-gke/templates/gke-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress }}
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Ingress
 metadata:
   name: {{ .Values.projectName }}-istio-ingress


### PR DESCRIPTION
Upgrade the beta version to stable version of k8s cluster API 
### [GCP Refrence Link](https://cloud.google.com/kubernetes-engine/docs/deprecations/apis-1-22?_ga=2.231737372.-228808259.1661167590&_gac=1.49415954.1661167884.EAIaIQobChMItL-wvqva-QIVgx0rCh3QJQAwEAAYASAAEgJHTfD_BwE#v1-manifest) 
