### PR TITLE
VAN-2984 | Adding condition for handle deprecated k8s API

### DIFF
--- a/helm/gcp/basic-gke/templates/ingress.yaml
+++ b/helm/gcp/basic-gke/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- $apiV := .Capabilities.APIVersions -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -16,24 +17,42 @@ metadata:
 spec:
 {{- $len := len .Values.ports }}
 {{- if eq $len 1 }}
+  {{- if  .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+  defaultBackend:
+    service:
+      name: {{ $.Values.applicationName }}
+      {{- range  $index,$port := .Values.ports }}
+      {{- if eq $index  0}}
+      port:
+        number: {{ int $port.containerPort }}
+      {{- end}}
+      {{- end}}      
+  {{- else }}
   backend:
     serviceName: {{ .Values.applicationName }}
     {{- range  $index,$port := .Values.ports }}
     {{- if eq $index  0}}
-    servicePort: {{$port.name}}
+    servicePort: {{ int $port.containerPort }}
     {{- end}}
     {{- end}}
+  {{- end}}  
 {{- else}}
   rules:
   - http:
       paths:
       {{- range $index,$port := .Values.ports }}
       - path: /{{$port.name}}/*
-        pathType: Prefix 
+        {{- if  $apiV.Has "networking.k8s.io/v1" }}
+        pathType: Prefix
         backend:
           service:
             name: {{ $.Values.applicationName }}
-            port: 
-              number: {{ $port.name}}
+            port:
+              number: {{ int $port.containerPort}}
+        {{- else }}
+        backend:
+          serviceName: {{ $.Values.applicationName }}
+          servicePort: {{ $port.containerPort }}
+        {{- end}}  
       {{- end}}
 {{- end }}

--- a/helm/gcp/basic-gke/templates/ingress.yaml
+++ b/helm/gcp/basic-gke/templates/ingress.yaml
@@ -1,4 +1,10 @@
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ .Values.applicationName }}-ingress
@@ -23,8 +29,11 @@ spec:
       paths:
       {{- range $index,$port := .Values.ports }}
       - path: /{{$port.name}}/*
+        pathType: Prefix 
         backend:
-          serviceName: {{ $.Values.applicationName }}
-          servicePort: {{ $port.name}}
+          service:
+            name: {{ $.Values.applicationName }}
+            port: 
+              number: {{ $port.name}}
       {{- end}}
 {{- end }}

--- a/helm/gcp/istio-gke/templates/gke-ingress.yaml
+++ b/helm/gcp/istio-gke/templates/gke-ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingress }}
+{{- $apiV := .Capabilities.APIVersions -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -23,16 +24,23 @@ spec:
     http:
       paths:
       - path: /*
+        {{- if  $apiV.Has "networking.k8s.io/v1" }}
         pathType: Prefix
+        backend:
+          service:
+            name: istio-ingressgateway
+            port:
+              number: 80
+        {{- else }}
         backend:
           # In this case we don't go directly to app-specific services,
           # but first to the Istio ingress-gateway
           # We use port 80 because it is the "ingress-like" port of the ingress-gateway
-          service:
-            name: istio-ingressgateway
-            port: 
-              number: 80
+          serviceName: istio-ingressgateway
+          servicePort: 80
+        {{- end}}  
   {{- end }}
+
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/helm/gcp/istio-gke/templates/gke-ingress.yaml
+++ b/helm/gcp/istio-gke/templates/gke-ingress.yaml
@@ -1,5 +1,11 @@
 {{- if .Values.ingress }}
-apiVersion: extensions/v1
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ .Values.projectName }}-istio-ingress
@@ -17,12 +23,15 @@ spec:
     http:
       paths:
       - path: /*
+        pathType: Prefix
         backend:
           # In this case we don't go directly to app-specific services,
           # but first to the Istio ingress-gateway
           # We use port 80 because it is the "ingress-like" port of the ingress-gateway
-          serviceName: istio-ingressgateway
-          servicePort: 80
+          service:
+            name: istio-ingressgateway
+            port: 
+              number: 80
   {{- end }}
 ---
 apiVersion: networking.istio.io/v1alpha3


### PR DESCRIPTION
API decrpated for k8s version >=1.22+

`Ingress` and `IngressClass` resources have graduated to `networking.k8s.io/v1`. Ingress and IngressClass types in the `extensions/v1beta1` and `networking.k8s.io/v1beta1` API versions are deprecated and will no longer be served in 1.22+. Persisted objects can be accessed via the `networking.k8s.io/v1` API. Notable changes in v1 Ingress objects (v1beta1 field names are unchanged):
* `spec.backend` -> `spec.defaultBackend`
* `serviceName` -> `service.name`
* `servicePort` -> `service.port.name` (for string values)
* `servicePort` -> `service.port.number` (for numeric values)
* `pathType` no longer has a default value in v1; "Exact", "Prefix", or "ImplementationSpecific" must be specified
Other Ingress API updates:
* backends can now be resource or service backends
* `path` is no longer required to be a valid regular expression
