### PR TITLE
VAN-3207 fix integer vs number usage

### DIFF
--- a/pipeline-modules/app-service/aws/test_module.yaml
+++ b/pipeline-modules/app-service/aws/test_module.yaml
@@ -18,7 +18,7 @@ inputs:
     echo_int:
       title: Echo Integer value
       description: The integer to echo to the log.
-      type: number
+      type: integer
     echo_list:
       title: Echo List value
       description: The List to echo to the log.

--- a/pipeline-modules/app-service/azure/test_module.yaml
+++ b/pipeline-modules/app-service/azure/test_module.yaml
@@ -21,7 +21,7 @@ inputs:
     echo_int:
       title: Echo Integer value
       description: The integer to echo to the log.
-      type: number
+      type: integer
     echo_list:
       title: Echo List value
       description: The List to echo to the log.

--- a/pipeline-modules/app-service/gcp/pipeline-config.yaml
+++ b/pipeline-modules/app-service/gcp/pipeline-config.yaml
@@ -20,7 +20,7 @@ inputs:
     pipeline_disk_size_gb:
       title: Disk Size [GB]
       description: Amount of disk space in GB allocated for the pipeline.
-      type: number
+      type: integer
       default: 300
       maximum: 1000
     pipeline_env:

--- a/pipeline-modules/app-service/gcp/test_module.yaml
+++ b/pipeline-modules/app-service/gcp/test_module.yaml
@@ -18,7 +18,7 @@ inputs:
     echo_int:
       title: Echo Integer value
       description: The integer to echo to the log.
-      type: number
+      type: integer
     echo_list:
       title: Echo List value
       description: The List to echo to the log.

--- a/pipeline-modules/deployment-service/aws/test_module.yaml
+++ b/pipeline-modules/deployment-service/aws/test_module.yaml
@@ -21,7 +21,7 @@ inputs:
     echo_int:
       title: Echo Integer value
       description: The integer to echo to the log.
-      type: number
+      type: integer
     echo_list:
       title: Echo List value
       description: The List to echo to the log.

--- a/pipeline-modules/deployment-service/azure/test_module.yaml
+++ b/pipeline-modules/deployment-service/azure/test_module.yaml
@@ -21,7 +21,7 @@ inputs:
     echo_int:
       title: Echo Integer value
       description: The integer to echo to the log.
-      type: number
+      type: integer
     echo_list:
       title: Echo List value
       description: The List to echo to the log.

--- a/pipeline-modules/deployment-service/gcp/pipeline-config.yaml
+++ b/pipeline-modules/deployment-service/gcp/pipeline-config.yaml
@@ -20,7 +20,7 @@ inputs:
     pipeline_disk_size_gb:
       title: Disk Size [GB]
       description: Amount of disk space in GB allocated for the pipeline.
-      type: number
+      type: integer
       default: 300
       maximum: 1000
     pipeline_env:

--- a/pipeline-modules/deployment-service/gcp/test_module.yaml
+++ b/pipeline-modules/deployment-service/gcp/test_module.yaml
@@ -21,7 +21,7 @@ inputs:
     echo_int:
       title: Echo Integer value
       description: The integer to echo to the log.
-      type: number
+      type: integer
     echo_list:
       title: Echo List value
       description: The List to echo to the log.

--- a/pipeline-modules/infra-service/aws/test_module.yaml
+++ b/pipeline-modules/infra-service/aws/test_module.yaml
@@ -18,7 +18,7 @@ inputs:
     echo_int:
       title: Echo Integer value
       description: The integer to echo to the log.
-      type: number
+      type: integer
     echo_list:
       title: Echo List value
       description: The List to echo to the log.

--- a/pipeline-modules/infra-service/gcp/pipeline-config.yaml
+++ b/pipeline-modules/infra-service/gcp/pipeline-config.yaml
@@ -20,7 +20,7 @@ inputs:
     pipeline_disk_size_gb:
       title: Disk Size [GB]
       description: Amount of disk space in GB allocated for the pipeline.
-      type: number
+      type: integer
       default: 300
       maximum: 1000
     pipeline_env:

--- a/pipeline-modules/infra-service/gcp/test_module.yaml
+++ b/pipeline-modules/infra-service/gcp/test_module.yaml
@@ -18,7 +18,7 @@ inputs:
     echo_int:
       title: Echo Integer value
       description: The integer to echo to the log.
-      type: number
+      type: integer
     echo_list:
       title: Echo List value
       description: The List to echo to the log.


### PR DESCRIPTION
Some modules declares inputs as number type where as it really needs integer type.
This change fixes the issue.