### PR TITLE
VAN-3376 Add deployment template for bash script

### DIFF
--- a/pipeline-modules/common/aws/env-files.yaml
+++ b/pipeline-modules/common/aws/env-files.yaml
@@ -14,11 +14,11 @@ meta: {}
 template: |
   {% set workspace = '$CODEBUILD_SRC_DIR' %}   {# has to be a persistent volume #}
   {% set pipeline_env_file = workspace|add:'/.env' %}
-  {% set pipeline_env_file = workspace|add:'/.secret.env' %}
+  {% set pipeline_secret_env_file = workspace|add:'/.secret.env' %}
 
   version: 0.2
   phases:
     pre_build:
       commands:
         - create-env-file.sh {{ pipeline_env_file }} ${__VG_EXPORTED_ENV_NAMES}
-        - create-env-file.sh {{ pipeline_env_file }} ${__VG_EXPORTED_ENV_NAMES}
+        - create-env-file.sh {{ pipeline_secret_env_file }} ${__VG_EXPORTED_SECRET_ENV_NAMES}

--- a/pipeline-modules/deployment-service/aws/run-bash-script.yaml
+++ b/pipeline-modules/deployment-service/aws/run-bash-script.yaml
@@ -1,0 +1,80 @@
+provisioner: aws
+name: run-bash-script
+version: 1
+revision: 1
+displayName: Execute a bash script
+description: Execute a bash script from file
+target: "deployment-template"
+keywords:
+  - bash
+  - linux
+author: CloudCover
+meta:
+  inputArtifactType:
+    - GitCode
+
+inputs:
+  properties:
+    bash_script:
+      title: Bash script
+      description: This the filename of the bash script to run
+      type: string
+    script_parameters:
+      title: Parameters to pass to the bash script
+      type: array
+      default: []
+      items:
+        type: string
+    repo_dir:
+      title: Repo Dir
+      description: Repo Dir
+      type: string
+    job_type:
+      title: Job Type
+      description: This is to deploy or undeploy application
+      type: string
+      default: deploy
+    pipeline_summary_var:
+      title: Pipeline Summary
+      description: This will create pipeline summary as per user request
+      type: array
+      default: []
+      items:
+        type: object
+        required: [Command, Name]
+        properties:
+          Command:
+            title: Command
+            type: string
+          Name:
+            title: Name
+            type: string
+  required:
+    - bash_script
+  internal:
+    - pipeline_summary_var
+    - repo_dir
+    - job_type
+template: |
+  {% set workspace = '$CODEBUILD_SRC_DIR' %}   {# has to be a persistent volume #}
+  {% set pipeline_env_file = workspace|add:'/.env' %}
+  {% set pipeline_secret_env_file = workspace|add:'/.secret.env' %}
+  {% set source_code_path = workspace|add:'/source_code' %}
+  version: 0.2
+  phases:
+    build:
+      commands:
+        - export CODEPIPES_DEPLOY_ACTION={{ job_type }}
+        - if [ -f {{ pipeline_env_file }} ]; then source {{ pipeline_env_file }}; fi
+        - if [ -f {{ pipeline_secret_env_file }} ]; then source {{ pipeline_secret_env_file }}; fi
+        - cd {{ source_code_path }}/{{ repo_dir }}
+        - ./{{ bash_script }} {% for param in script_parameters %}{{param}} {% endfor %}
+    post_build:
+      commands:
+        - echo "###pipeline-summary-start###" >> summary.txt 2>&1
+        {% if pipeline_summary_var %}
+        - {% for summary in pipeline_summary_var %} {{ summary.Command }} | xargs -0 printf "{{ summary.Name }}=%s\n" >>  summary.txt 2>&1; {% endfor %}
+        {% endif %}
+        - echo "Completion Status=[bash script completed {{ job_type }} at $(date)]" >> summary.txt 2>&1
+        - echo "###pipeline-summary-end###" >> summary.txt 2>&1
+        - cat summary.txt

--- a/pipeline-modules/deployment-service/azure/artifact-config.yaml
+++ b/pipeline-modules/deployment-service/azure/artifact-config.yaml
@@ -36,7 +36,7 @@ inputs:
     - repo_dir
     - artifact_type
 template: |
-  {% set workspace = '$(Pipeline.Workspace)' %}
+  {% set workspace = '$(Build.SourcesDirectory)' %}
   {% set source_code_path = workspace|add:'/source_code' %}
   {% set git_creds_path = '$HOME/.git-credentials' %}
   {% set git_config_path = '$HOME/.gitconfig' %}

--- a/pipeline-modules/deployment-service/azure/run-bash-script.yaml
+++ b/pipeline-modules/deployment-service/azure/run-bash-script.yaml
@@ -1,0 +1,92 @@
+provisioner: azure
+name: run-bash-script
+version: 1
+revision: 1
+displayName: Execute a bash script
+description: Execute a bash script from a file
+target: "deployment-template"
+keywords:
+  - bash
+  - linux
+author: CloudCover
+meta:
+  inputArtifactType:
+    - GitCode
+
+inputs:
+  properties:
+    bash_script:
+      title: Bash script
+      description: This the filename of the bash script to run
+      type: string
+    script_parameters:
+      title: Parameters to pass to the bash script
+      type: array
+      default: []
+      items:
+        type: string
+    repo_dir:
+      title: Repo Dir
+      description: Repo Dir
+      type: string
+    job_type:
+      title: Job Type
+      description: This is to deploy or undeploy application
+      type: string
+      default: deploy
+    pipeline_summary_var:
+      title: Pipeline Summary
+      description: This will create pipeline summary as per user request
+      type: array
+      default: []
+      items:
+        type: object
+        required: [Command, Name]
+        properties:
+          Command:
+            title: Command
+            type: string
+          Name:
+            title: Name
+            type: string
+    pipeline_secret_env:
+      title: Global Secret Environment
+      description: Mapping of globally available secret variable id.
+      type: object
+      default: {}
+  required:
+    - bash_script
+  internal:
+    - pipeline_secret_env
+    - pipeline_summary_var
+    - repo_dir
+    - job_type
+template: |
+  {% set workspace = '$(Build.SourcesDirectory)' %}
+  {% set pipeline_env_file = workspace|add:'/.env' %}
+  {% set pipeline_secret_env_file = workspace|add:'/.secret.env' %}
+  {% set source_code_path = workspace|add:'/source_code' %}
+
+  steps:
+  - script: |
+      export CODEPIPES_DEPLOY_ACTION={{ job_type }} ;
+      if [ -f {{ pipeline_env_file }} ]; then source {{ pipeline_env_file }}; fi ;
+      cd {{ source_code_path }}/{{ repo_dir }}
+      ./{{ bash_script }} {% for param in script_parameters %}{{param}} {% endfor %} ;
+    {% if pipeline_secret_env %}
+    env:
+    {% for env_key in pipeline_secret_env %}
+      {{ env_key}}: $({{ env_key }})
+    {% endfor -%}
+    {% endif %}
+    displayName: 'Execute bash script'
+  - script: |
+      echo "###pipeline-summary-start###" >> summary.txt 2>&1;
+      {% if pipeline_summary_var %}
+      {% for summary in pipeline_summary_var %}
+      {{ summary.Command }} | xargs -0 printf "{{ summary.Name }}=%s\n" >>  summary.txt 2>&1; {% endfor %}
+      {% endif %}
+      echo "Completion Status=[bash script completed {{ job_type }} at $(date)]" >> summary.txt 2>&1;
+      echo "###pipeline-summary-end###" >> summary.txt 2>&1;
+      cat summary.txt;
+    displayName: 'Extract summary vars'

--- a/pipeline-modules/deployment-service/gcp/run-bash-script.yaml
+++ b/pipeline-modules/deployment-service/gcp/run-bash-script.yaml
@@ -1,0 +1,89 @@
+provisioner: gcp
+name: run-bash-script
+version: 1
+revision: 1
+displayName: Execute a bash script
+description: Execute a bash script from a file
+target: "deployment-template"
+keywords:
+  - bash
+  - linux
+author: CloudCover
+meta:
+  inputArtifactType:
+    - GitCode
+
+inputs:
+  properties:
+    bash_script:
+      title: Bash script
+      description: This the filename of the bash script to run
+      type: string
+    script_parameters:
+      title: Parameters to pass to the bash script
+      type: array
+      default: []
+      items:
+        type: string
+    repo_dir:
+      title: Repo Dir
+      description: Repo Dir
+      type: string
+    job_type:
+      title: Job Type
+      description: This is to deploy or undeploy application
+      type: string
+      default: deploy
+    pipeline_summary_var:
+      title: Pipeline Summary
+      description: This will create pipeline summary as per user request
+      type: array
+      default: []
+      items:
+        type: object
+        required: [Command, Name]
+        properties:
+          Command:
+            title: Command
+            type: string
+          Name:
+            title: Name
+            type: string
+  required:
+    - bash_script
+  internal:
+    - job_type
+    - pipeline_summary_var
+    - repo_dir
+template: |
+  {% set workspace = '/workspace' %}   {# has to be a persistent volume #}
+  {% set pipeline_env_file = workspace|add:'/.env' %}
+  {% set pipeline_secret_env_file = workspace|add:'/.secret.env' %}
+  {% set source_code_path = workspace|add:'/source_code' %}
+
+  steps:
+  - id: 'Execute bash script'
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+    - '-c'
+    - |
+      export CODEPIPES_DEPLOY_ACTION={{ job_type }}
+      if [ -f {{ pipeline_env_file }} ]; then source {{ pipeline_env_file }}; fi
+      if [ -f {{ pipeline_secret_env_file }} ]; then source {{ pipeline_secret_env_file }}; fi
+      cd {{ source_code_path }}/{{ repo_dir }}
+      ./{{ bash_script }} {% for param in script_parameters %}{{param}} {% endfor %} ;
+  - id: 'Extract summary vars'
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+    - '-c'
+    - |
+      echo "###pipeline-summary-start###" >> summary.txt 2>&1;
+      {% if pipeline_summary_var %}
+      {% for summary in pipeline_summary_var %}
+      {{ summary.Command }} | xargs -0 printf "{{ summary.Name }}=%s\n" >>  summary.txt 2>&1; {% endfor %}
+      {% endif %}
+      echo "Completion Status=[bash script completed {{ job_type }} at $(date)]" >> summary.txt 2>&1;
+      echo "###pipeline-summary-end###" >> summary.txt 2>&1;
+      cat summary.txt;


### PR DESCRIPTION
Added a new deployment template - run-bash-script - for
AWS, GCP and Azure. It expects a GitCode artifact and the
name of a Bash script file that is present in the Git repo.
A list of parameters to the script can be provided and are
passed to the script when it is run.

All of the env vars (secret and not) are made available
to the script as well.

The pipeline exports an env var - CODEPIPES_DEPLOY_ACTION -
which can be used by the called script to distinguish between
"deploy" and "undeploy".