### PR TITLE
VAN-3421 Fix issue with checking out branch

### DIFF
--- a/pipeline-modules/deployment-service/azure/pipeline-config.yaml
+++ b/pipeline-modules/deployment-service/azure/pipeline-config.yaml
@@ -121,7 +121,7 @@ template: |
           git clone $git_repo --single-branch {{source_code_path}}
           cd {{source_code_path}}
           git fetch $git_repo {{tag}}
-          git checkout {{tag}}
+          git checkout FETCH_HEAD
           ls {{source_code_path}}/{{repo_dir}}/
       fi
   variables:


### PR DESCRIPTION
When using the --single-branch flag on git clone you can't necessarily checkout branches/tags after the fetch. Better to use checkout FETCH_HEAD as that will always work.