### PR TITLE
VAN-3243 Add pipeline module to call make targets

### DIFF
--- a/cloud-builders/make/Dockerfile
+++ b/cloud-builders/make/Dockerfile
@@ -1,0 +1,17 @@
+ARG GO_VERSION=1.18-alpine
+FROM golang:$GO_VERSION
+
+ARG JQ_VERSION=1.6
+ARG CP_ASSETS_PATH=/workspace/pipeline_modules/assets/scripts
+
+RUN apk --update add --no-cache curl git wget bash build-base && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/cache/apk/*
+
+RUN curl -sLJO https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 && \
+    chmod +x jq-linux64 && \
+    mv jq-linux64 /usr/local/bin/jq
+
+ENV PATH=$CP_ASSETS_PATH:$PATH
+
+ENTRYPOINT ["make"]

--- a/pipeline-modules/app-service/aws/bash.yaml
+++ b/pipeline-modules/app-service/aws/bash.yaml
@@ -5,7 +5,7 @@ revision: 1
 displayName: Bash script
 description: The bash script to run
 target: ""
-category: bash
+category: utility
 keywords:
   - bash
   - linux

--- a/pipeline-modules/app-service/aws/make-target.yaml
+++ b/pipeline-modules/app-service/aws/make-target.yaml
@@ -1,0 +1,58 @@
+provisioner: aws
+name: make-target
+version: 1
+revision: 1
+displayName: Makefile Target
+description: Execute a target in a Makefile
+target: ""
+category: utility
+keywords:
+  - make
+  - linux
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    working_dir:
+      title: Working directory
+      description: The directory within the repo where the Makefile is located
+      type: string
+      default: repo
+    makefile_name:
+      title: Makefile name
+      description: Custom file name for Makefile
+      type: string
+      default: ""
+    targets:
+      title: Target definitions
+      description: The Makefile target to execute
+      type: array
+      default: []
+      items:
+        type: object
+        required:
+          - name
+        properties:
+          name:
+            title: Target name
+            description: Name of the target to execute
+            type: string
+          target_dir:
+            title: Target working directory
+            description: Working directory for this target
+            type: string
+            default: "."
+
+template: |
+  {% set workspace = '$CODEBUILD_SRC_DIR' %}   {# has to be a persistent volume #}
+
+  version: 0.2
+  env:
+    shell: bash
+  phases:
+    build:
+      commands:
+        {% for target in targets %}
+        - cd {{ workspace }}/{{ working_dir }}/{{ target.target_dir }}
+        - make {% if makefile_name %}-f {{ makefile_name }}{% endif %} {{ target.name }}
+        {% endfor %}

--- a/pipeline-modules/app-service/azure/bash.yaml
+++ b/pipeline-modules/app-service/azure/bash.yaml
@@ -5,7 +5,7 @@ revision: 1
 displayName: Bash script
 description: Execute a bash script
 target: ""
-category: bash
+category: utility
 keywords:
   - bash
   - linux
@@ -34,7 +34,7 @@ template: |
     - task: Bash@3
       inputs:
         targetType: inline
-        working_dir: {{ working_dir }}
+        workingDirectory: {{ working_dir }}
         script: |
           set -x
           {{ bash_script }}

--- a/pipeline-modules/app-service/azure/make-target.yaml
+++ b/pipeline-modules/app-service/azure/make-target.yaml
@@ -1,0 +1,70 @@
+provisioner: azure
+name: make-target
+version: 1
+revision: 1
+displayName: Makefile Target
+description: Execute a target in a Makefile
+target: ""
+category: utility
+keywords:
+  - make
+  - linux
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    working_dir:
+      title: Working directory
+      description: The directory within the repo where the Makefile is located
+      type: string
+      default: repo
+    makefile_name:
+      title: Makefile name
+      description: Custom file name for Makefile
+      type: string
+      default: ""
+    targets:
+      title: Target definitions
+      description: The Makefile target to execute
+      type: array
+      default: []
+      items:
+        type: object
+        required:
+          - name
+        properties:
+          name:
+            title: Target name
+            description: Name of the target to execute
+            type: string
+          target_dir:
+            title: Target working directory
+            description: Working directory for this target
+            type: string
+            default: "."
+    pipeline_secret_env:
+      title: Global Secret Environment
+      description: Mapping of globally available secret variable id.
+      type: object
+      default: {}
+internal:
+  - pipeline_secret_env
+
+template: |
+  steps:
+    {% for target in targets %}
+    - task: Bash@3
+      displayName: Make {{ target.name }}
+      inputs:
+        targetType: inline
+        workingDirectory: {{ working_dir }}/{{ target.target_dir }}
+        script: |
+          set -x
+          make {% if makefile_name %}-f {{ makefile_name }}{% endif %} {{ target.name }} 
+      {% if pipeline_secret_env %}
+      env:
+        {% for env_key in pipeline_secret_env %}
+        {{ env_key}}: $({{ env_key }})
+        {% endfor -%}
+      {% endif %}
+    {% endfor %}

--- a/pipeline-modules/app-service/gcp/bash.yaml
+++ b/pipeline-modules/app-service/gcp/bash.yaml
@@ -5,7 +5,7 @@ revision: 1
 displayName: Bash script
 description: The bash script to run
 target: ""
-category: bash
+category: utility
 keywords:
   - bash
   - linux

--- a/pipeline-modules/app-service/gcp/make-target.yaml
+++ b/pipeline-modules/app-service/gcp/make-target.yaml
@@ -1,0 +1,58 @@
+provisioner: gcp
+name: make-target
+version: 1
+revision: 1
+displayName: Makefile Target
+description: Execute a target in a Makefile
+target: ""
+category: utility
+keywords:
+  - make
+  - linux
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    working_dir:
+      title: Working directory
+      description: The directory within the repo where the Makefile is located
+      type: string
+      default: repo
+    makefile_name:
+      title: Makefile name
+      description: Custom file name for Makefile
+      type: string
+      default: ""
+    targets:
+      title: Target definitions
+      description: The Makefile target to execute
+      type: array
+      default: []
+      items:
+        type: object
+        required:
+          - name
+        properties:
+          name:
+            title: Target name
+            description: Name of the target to execute
+            type: string
+          target_dir:
+            title: Target working directory
+            description: Working directory for this target
+            type: string
+            default: "."
+
+template: |
+  {% set workspace = '/workspace' %}   {# has to be a persistent volume #}
+
+  steps:
+    {% for target in targets %}
+  - name: 'cldcvr/cpi-make'
+    dir: {{ workspace }}/{{ working_dir }}/{{ target.target_dir }}
+    args:
+      {% if makefile_name %}
+      - -f {{ makefile_name }}
+      {% endif %}
+      - '{{ target.name }}'
+    {% endfor %}

--- a/pipeline-modules/common/azure/env-files.yaml
+++ b/pipeline-modules/common/azure/env-files.yaml
@@ -11,6 +11,16 @@ keywords:
   - cp_internal
 author: CloudCover
 meta: {}
+inputs:
+  properties:
+    pipeline_secret_env:
+      title: Global Secret Environment
+      description: Mapping of globally available secret variable id.
+      type: object
+      default: {}
+internal:
+  - pipeline_secret_env
+
 template: |
   {% set workspace = '$BUILD_SOURCESDIRECTORY' %}
   {% set pipeline_env_file = workspace|add:'/.env' %}
@@ -20,3 +30,9 @@ template: |
   - script: |
       create-env-file.sh {{ pipeline_env_file }} $(__VG_EXPORTED_ENV_NAMES)
       create-env-file.sh {{ pipeline_secret_file }} $(__VG_EXPORTED_SECRET_ENV_NAMES)
+    {% if pipeline_secret_env %}
+    env:
+    {% for env_key in pipeline_secret_env %}
+      {{ env_key}}: $({{ env_key }})
+    {% endfor -%}
+    {% endif %}


### PR DESCRIPTION
Added "make-target" pipeline module for AWS, Azure and GCP. This
module allows the integration pipeline to call 1 or more targets
in a make file in sequence.

In order to have the secret env vars available to any downstream
processes (like references in the Makefile), needed to add an
"env" stanza to any steps/tasks that needed them. Also did this
for the env-files module as it won't actually work without this.

For GCP, this pipeline module also includes a new cloud-builder
container.

Also, recategorized "bash" to "utility" as I think it shows up
better in the UI this way.
