### PR TITLE
VAN-3376 Add deployment template for bash script

### DIFF
--- a/assets/scripts/git-clone.sh
+++ b/assets/scripts/git-clone.sh
@@ -8,7 +8,7 @@ GIT_REPO=$1
 GIT_REF=$2
 SOURCE_CODE_PATH=$3
 
-echo "=== ${sn}: Cloning Git repo ${GIT_REPO}"
+echo "=== ${sn}: Cloning Git repo ${GIT_REPO} with ref ${GIT_REF} into dir ${SOURCE_CODE_PATH}"
 
 mkdir -p ${SOURCE_CODE_PATH}
 git clone ${GIT_REPO} --single-branch ${SOURCE_CODE_PATH}

--- a/pipeline-modules/app-service/azure/make-target.yaml
+++ b/pipeline-modules/app-service/azure/make-target.yaml
@@ -61,8 +61,9 @@ template: |
         script: |
           set -x
           make {% if makefile_name %}-f {{ makefile_name }}{% endif %} {{ target.name }} 
-      {% if pipeline_secret_env %}
       env:
+        sha_tag: $(sha_tag)
+      {% if pipeline_secret_env %}
         {% for env_key in pipeline_secret_env %}
         {{ env_key}}: $({{ env_key }})
         {% endfor -%}

--- a/pipeline-modules/common/aws/env-files.yaml
+++ b/pipeline-modules/common/aws/env-files.yaml
@@ -14,11 +14,11 @@ meta: {}
 template: |
   {% set workspace = '$CODEBUILD_SRC_DIR' %}   {# has to be a persistent volume #}
   {% set pipeline_env_file = workspace|add:'/.env' %}
-  {% set pipeline_env_file = workspace|add:'/.secret.env' %}
+  {% set pipeline_secret_env_file = workspace|add:'/.secret.env' %}
 
   version: 0.2
   phases:
     pre_build:
       commands:
         - create-env-file.sh {{ pipeline_env_file }} ${__VG_EXPORTED_ENV_NAMES}
-        - create-env-file.sh {{ pipeline_env_file }} ${__VG_EXPORTED_ENV_NAMES}
+        - create-env-file.sh {{ pipeline_secret_env_file }} ${__VG_EXPORTED_SECRET_ENV_NAMES}

--- a/pipeline-modules/common/aws/git-clone.yaml
+++ b/pipeline-modules/common/aws/git-clone.yaml
@@ -28,17 +28,12 @@ inputs:
       title: Repository URL
       description: The repository to clone from.
       type: string
-    working_dir:
-      title: Working directory
-      description: The current working directory to execute command
-      type: string
-      default: repo
-  internal:
+  required:
     - git_remote_path
-    - working_dir
 template: |
   version: 0.2
   phases:
     build:
       commands:
         - git-clone.sh {{ git_remote_path }} {{ git_checkout_target }} {{ git_local_path }}
+        - export sha_tag=$(git -C {{ git_local_path }} log --format="%H" -n 1);

--- a/pipeline-modules/common/azure/git-clone.yaml
+++ b/pipeline-modules/common/azure/git-clone.yaml
@@ -28,16 +28,11 @@ inputs:
       title: Repository URL
       description: The repository to clone from.
       type: string
-  internal:
+  required:
     - git_remote_path
-    - git_local_path
-    - git_checkout_target
 template: |
   steps:
   - script: |
-      git clone {% if git_checkout_target %}--no-checkout{% endif %} {{ git_remote_path }} {{ git_local_path }}{% if git_checkout_target %}
-      cd {{ git_local_path }} && git checkout {{ git_checkout_target }} && cd .. {% endif %}
-      cd {{ git_local_path }}
-      sha_tag=$(git log --format="%H" -n 1);
-      echo "##vso[task.setvariable variable=sha_tag]$sha_tag"
+      git-clone.sh {{ git_remote_path }} {{ git_checkout_target }} {{ git_local_path }}
+      echo "##vso[task.setvariable variable=sha_tag]$(git -C {{ git_local_path }} log --format="%H" -n 1)"
     displayName: 'Git Clone'

--- a/pipeline-modules/common/gcp/git-clone.yaml
+++ b/pipeline-modules/common/gcp/git-clone.yaml
@@ -32,11 +32,9 @@ inputs:
     - git_remote_path
 template: |
   steps:
-  - name: 'gcr.io/cloud-builders/git'
-    entrypoint: 'bash'
+  - id: "Git Clone"
+    name: 'cldcvr/cpi-config'
     args:
     - '-c'
     - |
-      set -x && \
-      git clone {% if git_checkout_target %}--no-checkout{% endif %} {{ git_remote_path }} {{ git_local_path }}{% if git_checkout_target %} && \
-      cd {{ git_local_path }} && git checkout {{ git_checkout_target }}{% endif %}
+      git-clone.sh {{ git_remote_path }} {{ git_checkout_target }} {{ git_local_path }}

--- a/pipeline-modules/deployment-service/aws/artifact-config.yaml
+++ b/pipeline-modules/deployment-service/aws/artifact-config.yaml
@@ -49,4 +49,5 @@ template: |
         {% if artifact_type == 'GitCode' %}
         - git-config.sh ${git_username} ${git_password} {{ repository }} {{ git_config_path }} {{ git_creds_path }}
         - git-clone.sh {{ repository }} {{ tag }} {{ source_code_path }}
+        - export sha_tag=$(git -C {{ source_code_path }} log --format="%H" -n 1);
         {% endif %}

--- a/pipeline-modules/deployment-service/aws/run-bash-script.yaml
+++ b/pipeline-modules/deployment-service/aws/run-bash-script.yaml
@@ -1,0 +1,80 @@
+provisioner: aws
+name: run-bash-script
+version: 1
+revision: 1
+displayName: Execute a bash script
+description: Execute a bash script from file
+target: "deployment-template"
+keywords:
+  - bash
+  - linux
+author: CloudCover
+meta:
+  inputArtifactType:
+    - GitCode
+
+inputs:
+  properties:
+    bash_script:
+      title: Bash script
+      description: This the filename of the bash script to run
+      type: string
+    script_parameters:
+      title: Parameters to pass to the bash script
+      type: array
+      default: []
+      items:
+        type: string
+    repo_dir:
+      title: Repo Dir
+      description: Repo Dir
+      type: string
+    job_type:
+      title: Job Type
+      description: This is to deploy or undeploy application
+      type: string
+      default: deploy
+    pipeline_summary_var:
+      title: Pipeline Summary
+      description: This will create pipeline summary as per user request
+      type: array
+      default: []
+      items:
+        type: object
+        required: [Command, Name]
+        properties:
+          Command:
+            title: Command
+            type: string
+          Name:
+            title: Name
+            type: string
+  required:
+    - bash_script
+  internal:
+    - pipeline_summary_var
+    - repo_dir
+    - job_type
+template: |
+  {% set workspace = '$CODEBUILD_SRC_DIR' %}   {# has to be a persistent volume #}
+  {% set pipeline_env_file = workspace|add:'/.env' %}
+  {% set pipeline_secret_env_file = workspace|add:'/.secret.env' %}
+  {% set source_code_path = workspace|add:'/source_code' %}
+  version: 0.2
+  phases:
+    build:
+      commands:
+        - export CODEPIPES_DEPLOY_ACTION={{ job_type }}
+        - if [ -f {{ pipeline_env_file }} ]; then source {{ pipeline_env_file }}; fi
+        - if [ -f {{ pipeline_secret_env_file }} ]; then source {{ pipeline_secret_env_file }}; fi
+        - cd {{ source_code_path }}/{{ repo_dir }}
+        - ./{{ bash_script }} {% for param in script_parameters %}{{param}} {% endfor %}
+    post_build:
+      commands:
+        - echo "###pipeline-summary-start###" >> summary.txt 2>&1
+        {% if pipeline_summary_var %}
+        - {% for summary in pipeline_summary_var %} {{ summary.Command }} | xargs -0 printf "{{ summary.Name }}=%s\n" >>  summary.txt 2>&1; {% endfor %}
+        {% endif %}
+        - echo "Completion Status=[bash script completed {{ job_type }} at $(date)]" >> summary.txt 2>&1
+        - echo "###pipeline-summary-end###" >> summary.txt 2>&1
+        - cat summary.txt

--- a/pipeline-modules/deployment-service/aws/run-bash-script.yaml
+++ b/pipeline-modules/deployment-service/aws/run-bash-script.yaml
@@ -61,10 +61,12 @@ template: |
   {% set pipeline_secret_env_file = workspace|add:'/.secret.env' %}
   {% set source_code_path = workspace|add:'/source_code' %}
   version: 0.2
+  env:
+    variables:
+      CODEPIPES_DEPLOY_ACTION: "{{ job_type }}"
   phases:
     build:
       commands:
-        - export CODEPIPES_DEPLOY_ACTION={{ job_type }}
         - if [ -f {{ pipeline_env_file }} ]; then source {{ pipeline_env_file }}; fi
         - if [ -f {{ pipeline_secret_env_file }} ]; then source {{ pipeline_secret_env_file }}; fi
         - cd {{ source_code_path }}/{{ repo_dir }}

--- a/pipeline-modules/deployment-service/azure/artifact-config.yaml
+++ b/pipeline-modules/deployment-service/azure/artifact-config.yaml
@@ -36,7 +36,7 @@ inputs:
     - repo_dir
     - artifact_type
 template: |
-  {% set workspace = '$(Pipeline.Workspace)' %}
+  {% set workspace = '$(Build.SourcesDirectory)' %}
   {% set source_code_path = workspace|add:'/source_code' %}
   {% set git_creds_path = '$HOME/.git-credentials' %}
   {% set git_config_path = '$HOME/.gitconfig' %}
@@ -46,4 +46,5 @@ template: |
       {% if artifact_type == 'GitCode' %}
       git-config.sh $(git_username) $(GIT_PASSWORD) {{ repository }} {{ git_config_path }} {{ git_creds_path }}
       git-clone.sh {{ repository }} {{ tag }} {{ source_code_path }}
+      echo "##vso[task.setvariable variable=sha_tag]$$(git -C {{ source_code_path }} log --format="%H" -n 1)"
       {% endif %}

--- a/pipeline-modules/deployment-service/azure/run-bash-script.yaml
+++ b/pipeline-modules/deployment-service/azure/run-bash-script.yaml
@@ -69,16 +69,14 @@ template: |
 
   steps:
   - script: |
-      export CODEPIPES_DEPLOY_ACTION={{ job_type }} ;
       if [ -f {{ pipeline_env_file }} ]; then source {{ pipeline_env_file }}; fi ;
       cd {{ source_code_path }}/{{ repo_dir }}
       ./{{ bash_script }} {% for param in script_parameters %}{{param}} {% endfor %} ;
-    {% if pipeline_secret_env %}
     env:
+      CODEPIPES_DEPLOY_ACTION: {{ job_type }}
     {% for env_key in pipeline_secret_env %}
       {{ env_key}}: $({{ env_key }})
     {% endfor -%}
-    {% endif %}
     displayName: 'Execute bash script'
   - script: |
       echo "###pipeline-summary-start###" >> summary.txt 2>&1;

--- a/pipeline-modules/deployment-service/azure/run-bash-script.yaml
+++ b/pipeline-modules/deployment-service/azure/run-bash-script.yaml
@@ -1,0 +1,92 @@
+provisioner: azure
+name: run-bash-script
+version: 1
+revision: 1
+displayName: Execute a bash script
+description: Execute a bash script from a file
+target: "deployment-template"
+keywords:
+  - bash
+  - linux
+author: CloudCover
+meta:
+  inputArtifactType:
+    - GitCode
+
+inputs:
+  properties:
+    bash_script:
+      title: Bash script
+      description: This the filename of the bash script to run
+      type: string
+    script_parameters:
+      title: Parameters to pass to the bash script
+      type: array
+      default: []
+      items:
+        type: string
+    repo_dir:
+      title: Repo Dir
+      description: Repo Dir
+      type: string
+    job_type:
+      title: Job Type
+      description: This is to deploy or undeploy application
+      type: string
+      default: deploy
+    pipeline_summary_var:
+      title: Pipeline Summary
+      description: This will create pipeline summary as per user request
+      type: array
+      default: []
+      items:
+        type: object
+        required: [Command, Name]
+        properties:
+          Command:
+            title: Command
+            type: string
+          Name:
+            title: Name
+            type: string
+    pipeline_secret_env:
+      title: Global Secret Environment
+      description: Mapping of globally available secret variable id.
+      type: object
+      default: {}
+  required:
+    - bash_script
+  internal:
+    - pipeline_secret_env
+    - pipeline_summary_var
+    - repo_dir
+    - job_type
+template: |
+  {% set workspace = '$(Build.SourcesDirectory)' %}
+  {% set pipeline_env_file = workspace|add:'/.env' %}
+  {% set pipeline_secret_env_file = workspace|add:'/.secret.env' %}
+  {% set source_code_path = workspace|add:'/source_code' %}
+
+  steps:
+  - script: |
+      export CODEPIPES_DEPLOY_ACTION={{ job_type }} ;
+      if [ -f {{ pipeline_env_file }} ]; then source {{ pipeline_env_file }}; fi ;
+      cd {{ source_code_path }}/{{ repo_dir }}
+      ./{{ bash_script }} {% for param in script_parameters %}{{param}} {% endfor %} ;
+    {% if pipeline_secret_env %}
+    env:
+    {% for env_key in pipeline_secret_env %}
+      {{ env_key}}: $({{ env_key }})
+    {% endfor -%}
+    {% endif %}
+    displayName: 'Execute bash script'
+  - script: |
+      echo "###pipeline-summary-start###" >> summary.txt 2>&1;
+      {% if pipeline_summary_var %}
+      {% for summary in pipeline_summary_var %}
+      {{ summary.Command }} | xargs -0 printf "{{ summary.Name }}=%s\n" >>  summary.txt 2>&1; {% endfor %}
+      {% endif %}
+      echo "Completion Status=[bash script completed {{ job_type }} at $(date)]" >> summary.txt 2>&1;
+      echo "###pipeline-summary-end###" >> summary.txt 2>&1;
+      cat summary.txt;
+    displayName: 'Extract summary vars'

--- a/pipeline-modules/deployment-service/gcp/run-bash-script.yaml
+++ b/pipeline-modules/deployment-service/gcp/run-bash-script.yaml
@@ -68,11 +68,12 @@ template: |
     args:
     - '-c'
     - |
-      export CODEPIPES_DEPLOY_ACTION={{ job_type }}
       if [ -f {{ pipeline_env_file }} ]; then source {{ pipeline_env_file }}; fi
       if [ -f {{ pipeline_secret_env_file }} ]; then source {{ pipeline_secret_env_file }}; fi
       cd {{ source_code_path }}/{{ repo_dir }}
       ./{{ bash_script }} {% for param in script_parameters %}{{param}} {% endfor %} ;
+    env:
+    - 'CODEPIPES_DEPLOY_ACTION={{ job_type }}'
   - id: 'Extract summary vars'
     name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'

--- a/pipeline-modules/deployment-service/gcp/run-bash-script.yaml
+++ b/pipeline-modules/deployment-service/gcp/run-bash-script.yaml
@@ -1,0 +1,89 @@
+provisioner: gcp
+name: run-bash-script
+version: 1
+revision: 1
+displayName: Execute a bash script
+description: Execute a bash script from a file
+target: "deployment-template"
+keywords:
+  - bash
+  - linux
+author: CloudCover
+meta:
+  inputArtifactType:
+    - GitCode
+
+inputs:
+  properties:
+    bash_script:
+      title: Bash script
+      description: This the filename of the bash script to run
+      type: string
+    script_parameters:
+      title: Parameters to pass to the bash script
+      type: array
+      default: []
+      items:
+        type: string
+    repo_dir:
+      title: Repo Dir
+      description: Repo Dir
+      type: string
+    job_type:
+      title: Job Type
+      description: This is to deploy or undeploy application
+      type: string
+      default: deploy
+    pipeline_summary_var:
+      title: Pipeline Summary
+      description: This will create pipeline summary as per user request
+      type: array
+      default: []
+      items:
+        type: object
+        required: [Command, Name]
+        properties:
+          Command:
+            title: Command
+            type: string
+          Name:
+            title: Name
+            type: string
+  required:
+    - bash_script
+  internal:
+    - job_type
+    - pipeline_summary_var
+    - repo_dir
+template: |
+  {% set workspace = '/workspace' %}   {# has to be a persistent volume #}
+  {% set pipeline_env_file = workspace|add:'/.env' %}
+  {% set pipeline_secret_env_file = workspace|add:'/.secret.env' %}
+  {% set source_code_path = workspace|add:'/source_code' %}
+
+  steps:
+  - id: 'Execute bash script'
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+    - '-c'
+    - |
+      export CODEPIPES_DEPLOY_ACTION={{ job_type }}
+      if [ -f {{ pipeline_env_file }} ]; then source {{ pipeline_env_file }}; fi
+      if [ -f {{ pipeline_secret_env_file }} ]; then source {{ pipeline_secret_env_file }}; fi
+      cd {{ source_code_path }}/{{ repo_dir }}
+      ./{{ bash_script }} {% for param in script_parameters %}{{param}} {% endfor %} ;
+  - id: 'Extract summary vars'
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+    - '-c'
+    - |
+      echo "###pipeline-summary-start###" >> summary.txt 2>&1;
+      {% if pipeline_summary_var %}
+      {% for summary in pipeline_summary_var %}
+      {{ summary.Command }} | xargs -0 printf "{{ summary.Name }}=%s\n" >>  summary.txt 2>&1; {% endfor %}
+      {% endif %}
+      echo "Completion Status=[bash script completed {{ job_type }} at $(date)]" >> summary.txt 2>&1;
+      echo "###pipeline-summary-end###" >> summary.txt 2>&1;
+      cat summary.txt;


### PR DESCRIPTION
Added a new deployment template - run-bash-script - for
AWS, GCP and Azure. It expects a GitCode artifact and the
name of a Bash script file that is present in the Git repo.
A list of parameters to the script can be provided and are
passed to the script when it is run.

All of the env vars (secret and not) are made available
to the script as well.

The pipeline exports an env var - CODEPIPES_DEPLOY_ACTION -
which can be used by the called script to distinguish between
"deploy" and "undeploy".

While working on this I noticed a few things about the
common scripts that could be improved:
- common git-clone.yaml was missing for Azure and GCP
- Azure was exposing a Git SHA - have made that available for all
