### PR TITLE
VAN-3345 add default modules

### DIFF
--- a/pipeline-modules/app-service/aws/docker-build.yaml
+++ b/pipeline-modules/app-service/aws/docker-build.yaml
@@ -3,12 +3,19 @@ name: docker-build
 version: 1
 revision: 1
 displayName: Docker Build
-description: This plugin only builds the Docker image, useful for running checks
+description: Build the container image using docker cli
 target: ""
-category: containerise
+category: build
 keywords:
-  - Docker
-  - Build
+  - default
+  - ContainerImage
+  - go
+  - node
+  - java
+  - dotnet
+  - csharp
+  - html
+  - js
 author: CloudCover
 meta: {}
 inputs:
@@ -20,19 +27,30 @@ inputs:
       default: []
       items:
         type: string
+    container_repository:
+      title: Container repository
+      description: Complete repository path
+      type: string
+    container_tag:
+      title: Image Tag
+      description: Tag name for the container image
+      type: string
+      default: latest
     working_dir:
       title: Working directory
       description: The current working directory to execute command
       type: string
       default: repo
+  internal:
+    - container_repository
+    - container_tag
+    - working_dir
 template: |
   version: 0.2
-
   phases:
     build:
       commands:
         - echo Build started on `date`
-        - echo Building the Docker image...
-        - docker build -t temp {% for arg in docker_build_args %} {{ arg }} {% endfor %} .
+        - docker build -t {{container_repository}}:{{container_tag}} {% for arg in docker_build_args %} {{ arg }} {% endfor %} .
         - echo Build completed on `date`
 

--- a/pipeline-modules/app-service/aws/docker-push.yaml
+++ b/pipeline-modules/app-service/aws/docker-push.yaml
@@ -1,0 +1,60 @@
+provisioner: aws
+name: docker-push
+version: 1
+revision: 1
+displayName: Docker Push
+description: Push container image to a registry using docker cli
+target: ""
+category: push
+keywords:
+  - default
+  - ContainerImage
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    container_repository:
+      title: Container repository
+      description: Complete repository path
+      type: string
+    container_tag:
+      title: Image Tag
+      description: Tag name for the container image
+      type: string
+      default: latest
+    working_dir:
+      title: Working directory
+      description: The current working directory to execute command
+      type: string
+    use_github_tag:
+      title: Use github tag
+      description: true value will push the image reference with git commit sha tag as well
+      type: boolean
+      default: true
+    sha_tag:
+      title: SHA Git commit tag
+      description: Resolved Commit hash for Input git artifact
+      type: string
+  internal:
+    - container_repository
+    - container_tag
+    - sha_tag
+    - working_dir
+template: |
+  version: 0.2
+
+  phases:
+    build:
+      commands:
+        - cd {{working_dir}}
+        - echo Logging in to docker
+        - echo $docker_password | docker login -u $docker_username --password-stdin $docker_registry
+        - echo Pushing the Docker image...
+        - docker push {{container_repository}}:{{container_tag}}
+        {% if use_github_tag %}
+        - echo Creating new tag with Commit hash...
+        - docker tag {{container_repository}}:{{container_tag}} {{container_repository}}:{{sha_tag}}
+        - echo Pushing the Docker image with Commit hash...
+        - docker push {{container_repository}}:{{sha_tag}}
+        {% endif %}
+        

--- a/pipeline-modules/app-service/aws/java-unit-test.yaml
+++ b/pipeline-modules/app-service/aws/java-unit-test.yaml
@@ -7,6 +7,7 @@ description: run Java unit test with Maven
 target: ""
 category: unit test
 keywords:
+  - default
   - java
   - unit-test
   - maven

--- a/pipeline-modules/app-service/azure/docker-build.yaml
+++ b/pipeline-modules/app-service/azure/docker-build.yaml
@@ -3,12 +3,19 @@ name: docker-build
 version: 1
 revision: 1
 displayName: Docker Build
-description: This plugin only builds the Docker image, useful for running checks
+description: Build the container image using docker cli
 target: ""
-category: containerise
+category: build
 keywords:
-  - Docker
-  - Build
+  - default
+  - ContainerImage
+  - go
+  - node
+  - java
+  - dotnet
+  - csharp
+  - html
+  - js
 author: CloudCover
 meta: {}
 inputs:
@@ -20,17 +27,30 @@ inputs:
       default: []
       items:
         type: string
+    container_repository:
+      title: Container repository
+      description: Complete repository path
+      type: string
+    container_tag:
+      title: Image Tag
+      description: Tag name for the container image
+      type: string
+      default: latest
     working_dir:
       title: Working directory
       description: The current working directory to execute command
       type: string
       default: repo
+  internal:
+    - container_repository
+    - container_tag
+    - working_dir
 template: |
   steps:
   - script: |
       echo Build started on `date`
       Building the Docker image...
-      docker build -t temp {% for arg in docker_build_args %} {{ arg }} {% endfor %} .
+      docker build -t {{container_repository}}:{{container_tag}} {% for arg in docker_build_args %} {{ arg }} {% endfor %} .
       echo Build completed on `date`
     displayName: 'Docker Build'
     workingDirectory: {{ working_dir }}

--- a/pipeline-modules/app-service/azure/docker-push.yaml
+++ b/pipeline-modules/app-service/azure/docker-push.yaml
@@ -1,0 +1,58 @@
+provisioner: azure
+name: docker-push
+version: 1
+revision: 1
+displayName: Docker Push
+description: Push container image to a registry using docker cli
+target: ""
+category: push
+keywords:
+  - default
+  - ContainerImage
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    container_repository:
+      title: Container repository
+      description: Complete repository path
+      type: string
+    container_tag:
+      title: Image Tag
+      description: Tag name for the container image
+      type: string
+      default: latest
+    working_dir:
+      title: Working directory
+      description: The current working directory to execute command
+      type: string
+    use_github_tag:
+      title: Use github tag
+      description: true value will push the image reference with git commit sha tag as well
+      type: boolean
+      default: true
+    sha_tag:
+      title: SHA Git commit tag
+      description: Resolved Commit hash for Input git artifact
+      type: string
+  internal:
+    - container_repository
+    - container_tag
+    - sha_tag
+    - working_dir
+template: |
+  steps:
+  - script: |
+      echo Logging in to docker
+      docker login -u $(docker_username) -p $(docker_password) $(docker_registry)
+      echo Pushing the Docker image...
+      docker push {{container_repository}}:{{container_tag}}
+      
+      {% if use_github_tag == true %}
+      echo Pushing the Docker image with Commit hash...
+      docker tag {{container_repository}}:{{container_tag}} {{container_repository}}:{{sha_tag}}
+      docker push {{container_repository}}:{{sha_tag}}
+      {% endif %}
+
+    displayName: 'Docker Push'
+    workingDirectory: {{ working_dir }}

--- a/pipeline-modules/app-service/azure/java-unit-test.yaml
+++ b/pipeline-modules/app-service/azure/java-unit-test.yaml
@@ -7,6 +7,7 @@ description: run Java unit test with Maven
 target: ""
 category: unit test
 keywords:
+  - default
   - java
 author: CloudCover
 meta: {}

--- a/pipeline-modules/app-service/gcp/docker-build.yaml
+++ b/pipeline-modules/app-service/gcp/docker-build.yaml
@@ -3,12 +3,19 @@ name: docker-build
 version: 1
 revision: 1
 displayName: Docker Build
-description: This plugin only builds the Docker image, useful for running checks
+description: Build the container image using docker cli
 target: ""
-category: containerise
+category: build
 keywords:
-  - Docker
-  - Build
+  - default
+  - ContainerImage
+  - go
+  - node
+  - java
+  - dotnet
+  - csharp
+  - html
+  - js
 author: CloudCover
 meta: {}
 inputs:
@@ -17,21 +24,34 @@ inputs:
       title: Docker Build Arguments
       description: Arguments for the docker build command
       type: array
-      default: [".", "--tag", "temp"]
+      default: []
       items:
         type: string
+    container_repository:
+      title: Container repository
+      description: Complete repository path
+      type: string
+    container_tag:
+      title: Image Tag
+      description: Tag name for the container image
+      type: string
+      default: latest
     working_dir:
       title: Working directory
       description: The current working directory to execute command
       type: string
       default: repo
+  internal:
+    - container_repository
+    - container_tag
+    - working_dir
 template: |
   steps:
   - id: 'Docker Build'
     name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
     dir: {{ working_dir }}
     args:
-    - build
-    {% for arg in docker_build_args %}
-    - {{ arg }}
-    {% endfor %}
+    - '-c'
+    - |
+      docker build -t {{container_repository}}:{{container_tag}} {% for arg in docker_build_args %} {{ arg }} {% endfor %} .

--- a/pipeline-modules/app-service/gcp/docker-push.yaml
+++ b/pipeline-modules/app-service/gcp/docker-push.yaml
@@ -1,0 +1,57 @@
+provisioner: gcp
+name: docker-push
+version: 1
+revision: 1
+displayName: Docker Push
+description: Push container image to a registry using docker cli
+target: ""
+category: push
+keywords:
+  - default
+  - ContainerImage
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    container_repository:
+      title: Container repository
+      description: Complete repository path
+      type: string
+    container_tag:
+      title: Image Tag
+      description: Tag name for the container image
+      type: string
+      default: latest
+    working_dir:
+      title: Working directory
+      description: The current working directory to execute command
+      type: string
+    use_github_tag:
+      title: Use github tag
+      description: true value will push the image reference with git commit sha tag as well
+      type: boolean
+      default: true
+    sha_tag:
+      title: SHA Git commit tag
+      description: Resolved Commit hash for Input git artifact
+      type: string
+  internal:
+    - container_repository
+    - container_tag
+    - sha_tag
+    - working_dir
+template: |
+  steps:
+  - id: 'Docker Build and Push'
+    name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    dir: {{ working_dir }}
+    args:
+    - '-c'
+    - |
+      echo $$docker_password | docker login -u $$docker_username --password-stdin $$docker_registry
+      docker push {{container_repository}}:{{container_tag}}
+      {% if use_github_tag == true %}
+      docker tag {{container_repository}}:{{container_tag}} {{container_repository}}:{{sha_tag}}
+      docker push {{container_repository}}:{{sha_tag}}
+      {% endif %}


### PR DESCRIPTION
- Mark existing 'unit test' type modules as 'default'
- Mark existing 'Docker Build' modules as 'default' add more relevant keywords for discovery
- Add 'Docker Push' module split from docker-build-n-push