### PR TITLE
VAN-3734 Add SonarCloud and go-unittest modules

### DIFF
--- a/pipeline-modules/app-service/aws/go-unittest.yaml
+++ b/pipeline-modules/app-service/aws/go-unittest.yaml
@@ -1,0 +1,52 @@
+provisioner: aws
+name: go-unittest
+version: 1
+revision: 1
+displayName: Go Unit Test
+description: Runs units tests and collects code coverage data
+target: ""
+category: unit test
+keywords:
+  - default
+  - go
+  - Test
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    working_dir:
+      title: Working directory
+      description: The current working directory to execute command
+      type: string
+      default: repo
+    go_version:
+      title: Golang version
+      description: The version of Golang to use
+      type: string
+      default: latest
+    go_test_args:
+      title: Go Test args
+      description: Arguments for Go test command
+      type: array
+      items:
+        type: string
+      default: []
+    coverage_file:
+      title: Code Coverage file
+      description: Unit test coverage file to be analyzed by SonarCloud
+      type: string
+      default: "coverage.out"
+  internal:
+    - working_dir
+template: |
+  version: 0.2
+  phases:
+    build:
+      commands:
+        - CGO_ENABLED=${CGO_ENABLED:-0}
+        - GOPATH=$CODEBUILD_SRC_DIR
+        - echo Installing Golang v{{ go_version }}
+        - goenv install {{ go_version }}
+        - goenv local $(goenv versions | grep -m 1 {{ go_version }} | awk '{ print $1 }')
+        - cd $CODEBUILD_SRC_DIR/{{ working_dir }}
+        - go test -v -coverprofile={{ coverage_file }} -coverpkg ./... {% for arg in go_test_args %} {{ arg }} {% endfor %} ./...

--- a/pipeline-modules/app-service/aws/sonarcloud.yaml
+++ b/pipeline-modules/app-service/aws/sonarcloud.yaml
@@ -1,0 +1,84 @@
+provisioner: aws
+name: sonar-cloud
+version: 1
+revision: 1
+displayName: Sonar Cloud
+description: Analyze source code using Sonar Cloud
+target: ""
+category: code analysis
+keywords:
+  - Analyze Code
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    git_checkout_target:
+      title: Checkout Target
+      description: Git branch, tag or commit hash to checkout.
+      type: string
+      default: ""
+    git_local_path:
+      title: Local Clone Directory
+      description: The name of a new directory to clone into.
+      type: string
+      default: repo
+    sonar_cloud_url:
+      title: SonarCloud URL
+      description: URL for SonarCloud endpoint
+      type: string
+      default: "https://sonarcloud.io"
+    sonar_cloud_login_token:
+      title: Sonar Login Token
+      description: User generated token used to authenticate with Sonar Cloud
+      type: string
+    sonar_cloud_org:
+      title: Sonar Organization Key
+      description: Sonar organization key found in project information section of sonar cloud web console
+      type: string
+    sonar_cloud_project_key:
+      title: Sonar Project Key
+      description: Sonar project key found in project information section of sonar cloud web console. This is required if sonar_config_file is not set
+      type: string
+      default: ""
+    sonar_config_file:
+      title: Sonar config file name
+      description: Optionally, use a config file in the repo to setup sonar properties
+      type: string
+      default: ""
+    sonar_verbose_log:
+      title: Sonar log verbosity
+      description: Increase the verbosity of the Sonar log
+      type: boolean
+      default: false
+    coverage_file:
+      title: Code Coverage file
+      description: Unit test coverage file to be analyzed by SonarCloud
+      type: string
+      default: "coverage.out"
+  internal:
+    - git_checkout_target
+  required:
+    - sonar_cloud_login_token
+    - sonar_cloud_org
+template: |
+  version: 0.2
+
+  phases:
+    build:
+      commands:
+        - docker run --rm
+          -v $CODEBUILD_SRC_DIR:/usr/src
+          public.ecr.aws/p0k3r4s4/sonar-scanner-cli
+          -Dsonar.host.url={{ sonar_cloud_url }}
+          -Dsonar.login={{ sonar_cloud_login_token }}
+          -Dsonar.organization={{ sonar_cloud_org }}
+          {% if sonar_config_file -%}
+          -Dproject.settings={{ git_local_path }}/{{ sonar_config_file }}
+          {% else -%}
+          -Dsonar.projectKey={{ sonar_cloud_project_key }}
+          {%- endif %}
+          -Dsonar.projectBaseDir={{ git_local_path }}
+          -Dsonar.branch.name={{ git_checkout_target }}
+          -Dsonar.go.coverage.reportPaths={{ coverage_file }}
+          -Dsonar.qualitygate.wait=true
+          -Dsonar.verbose={{ sonar_verbose_log }}

--- a/pipeline-modules/app-service/azure/go-build.yaml
+++ b/pipeline-modules/app-service/azure/go-build.yaml
@@ -33,7 +33,7 @@ inputs:
       default: "1.15.15"
     pool_name:
       title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
+      description: Use selfhosted agent by providing agent pool name.
       type: string
       default: ""
   internal:

--- a/pipeline-modules/app-service/azure/go-unittest.yaml
+++ b/pipeline-modules/app-service/azure/go-unittest.yaml
@@ -1,0 +1,58 @@
+provisioner: azure
+name: go-unittest
+version: 1
+revision: 1
+displayName: Go Unit Test
+description: Runs units tests and collects code coverage data
+target: ""
+category: unit test
+keywords:
+  - default
+  - go
+  - Test
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    working_dir:
+      title: Working directory
+      description: The current working directory to execute command
+      type: string
+      default: repo
+    go_version:
+      title: Golang version
+      description: The version of Golang to use
+      type: string
+      default: latest
+    go_test_args:
+      title: Go Test args
+      description: Arguments for Go test command
+      type: array
+      items:
+        type: string
+      default: []
+    coverage_file:
+      title: Code Coverage file
+      description: Unit test coverage file to be analyzed by SonarCloud
+      type: string
+      default: "coverage.out"
+  internal:
+    - working_dir
+template: |
+  steps:
+  - task: GoTool@0
+    inputs:
+      version: {{go_version}}
+    displayName: "Install and Select go version {{go_version}}"
+  - script: |
+      export CGO_ENABLED=${CGO_ENABLED:-0}
+      export GOOS=${GOOS:-linux}
+      go version
+      go test -v -coverprofile={{ coverage_file }} -coverpkg ./... {% for arg in go_test_args %} {{ arg }} {% endfor %} ./...
+    displayName: 'Go Unit Tests with coverage'
+    workingDirectory: {{ working_dir }}
+  - task: PublishPipelineArtifact@1
+    displayName: "Save coverage file"
+    inputs:
+      targetPath: '{{ working_dir }}/{{ coverage_file }}'
+      artifactName: 'coverage'

--- a/pipeline-modules/app-service/azure/make-target.yaml
+++ b/pipeline-modules/app-service/azure/make-target.yaml
@@ -47,9 +47,15 @@ inputs:
       description: Mapping of globally available secret variable id.
       type: object
       default: {}
+    sha_tag:
+      title: SHA Git commit tag
+      description: Resolved Commit hash for Input git artifact
+      type: string
   internal:
+    - sha_tag
     - working_dir
     - pipeline_secret_env
+
 template: |
   steps:
     {% for target in targets %}
@@ -62,7 +68,7 @@ template: |
           set -x
           make {% if makefile_name %}-f {{ makefile_name }}{% endif %} {{ target.name }}
       env:
-        sha_tag: $(sha_tag)
+        sha_tag: {{ sha_tag }}
       {% if pipeline_secret_env %}
         {% for env_key in pipeline_secret_env %}
         {{ env_key}}: $({{ env_key }})

--- a/pipeline-modules/app-service/azure/sonarcloud.yaml
+++ b/pipeline-modules/app-service/azure/sonarcloud.yaml
@@ -40,6 +40,11 @@ inputs:
       description: Optionally, use a config file in the repo to setup sonar properties
       type: string
       default: ""
+    coverage_file:
+      title: Code Coverage file
+      description: Unit test coverage file to be analyzed by SonarCloud
+      type: string
+      default: "coverage.out"
     pool_name:
       title: Pool Name
       description: Use selfhosted agent by proving agent pool name.
@@ -55,6 +60,11 @@ template: |
         git fetch --all
       displayName: 'Git fetch base'
       workingDirectory: {{ git_local_path }}
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        buildType: 'current'
+        artifactName: 'coverage'
+        targetPath: '{{ git_local_path }}'
     - task: SonarCloudPrepare@1
       inputs:
         SonarCloud: {{ sonar_cloud_service_connection }}
@@ -69,6 +79,7 @@ template: |
         {%- endif %}
         extraProperties: |
           sonar.projectBaseDir={{ git_local_path }}
+          sonar.go.coverage.reportPaths={{ git_local_path }}/{{ coverage_file }}
           {% if git_checkout_target -%}
           sonar.scm.revision={{ git_checkout_target }}
           sonar.branch.name={{ git_checkout_target }}

--- a/pipeline-modules/app-service/gcp/go-unittest.yaml
+++ b/pipeline-modules/app-service/gcp/go-unittest.yaml
@@ -1,26 +1,19 @@
 provisioner: gcp
-name: go-build
+name: go-unittest
 version: 1
 revision: 1
-displayName: Go Build
-description: Build source code using Golang
+displayName: Go Unit Test
+description: Runs units tests and collects code coverage data
 target: ""
-category: build
+category: unit test
 keywords:
-  - Go
-  - Install
-  - Build
+  - default
+  - go
+  - Test
 author: CloudCover
 meta: {}
 inputs:
   properties:
-    go_build_args:
-      title: Go build args
-      description: Arguments for Go build command
-      type: array
-      default: []
-      items:
-        type: string
     working_dir:
       title: Working directory
       description: The current working directory to execute command
@@ -31,11 +24,23 @@ inputs:
       description: The version of Golang to use
       type: string
       default: latest
+    go_test_args:
+      title: Go Test args
+      description: Arguments for Go test command
+      type: array
+      items:
+        type: string
+      default: []
+    coverage_file:
+      title: Code Coverage file
+      description: Unit test coverage file to be analyzed by SonarCloud
+      type: string
+      default: "coverage.out"
   internal:
     - working_dir
 template: |
   steps:
-  - id: 'Go Build'
+  - id: go_unittest
     name: golang:{{ go_version }}
     dir: {{ working_dir }}
     env: ["GOPATH=/workspace", "CGO_ENABLED=${CGO_ENABLED:-0}"]
@@ -44,5 +49,4 @@ template: |
       - -c
       - |
         set -x
-        go version
-        go build -v {% for arg in go_build_args %} {{ arg }} {% endfor %}
+        go test -v -coverprofile={{ coverage_file }} -coverpkg ./... {% for arg in go_test_args %} {{ arg }} {% endfor %} ./...

--- a/pipeline-modules/app-service/gcp/sonarcloud.yaml
+++ b/pipeline-modules/app-service/gcp/sonarcloud.yaml
@@ -1,0 +1,81 @@
+provisioner: gcp
+name: sonar-cloud
+version: 1
+revision: 1
+displayName: Sonar Cloud
+description: Analyze source code using Sonar Cloud
+target: ""
+category: code analysis
+keywords:
+  - Analyze Code
+author: CloudCover
+meta: {}
+inputs:
+  properties:
+    git_checkout_target:
+      title: Checkout Target
+      description: Git branch, tag or commit hash to checkout.
+      type: string
+      default: ""
+    git_local_path:
+      title: Local Clone Directory
+      description: The name of a new directory to clone into.
+      type: string
+      default: repo
+    sonar_cloud_url:
+      title: SonarCloud URL
+      description: URL for SonarCloud endpoint
+      type: string
+      default: "https://sonarcloud.io"
+    sonar_cloud_login_token:
+      title: Sonar Login Token
+      description: User generated token used to authenticate with Sonar Cloud
+      type: string
+    sonar_cloud_org:
+      title: Sonar Organization Key
+      description: Sonar organization key found in project information section of sonar cloud web console
+      type: string
+    sonar_cloud_project_key:
+      title: Sonar Project Key
+      description: Sonar project key found in project information section of sonar cloud web console. This is required if sonar_config_file is not set
+      type: string
+      default: ""
+    sonar_config_file:
+      title: Sonar config file name
+      description: Optionally, use a config file in the repo to setup sonar properties
+      type: string
+      default: ""
+    sonar_verbose_log:
+      title: Sonar log verbosity
+      description: Increase the verbosity of the Sonar log
+      type: boolean
+      default: false
+    coverage_file:
+      title: Code Coverage file
+      description: Unit test coverage file to be analyzed by SonarCloud
+      type: string
+      default: "coverage.out"
+  internal:
+    - git_checkout_target
+  required:
+    - sonar_cloud_login_token
+    - sonar_cloud_org
+template: |
+  steps:
+  - id: 'Run scan on SonarCloud'
+    name: gcr.io/codepipes-staging/sonar-scanner-cli
+    args:
+    - 'sonar-scanner'
+    - '-Dsonar.host.url={{ sonar_cloud_url }}'
+    - '-Dsonar.login={{ sonar_cloud_login_token }}'
+    - '-Dsonar.organization={{ sonar_cloud_org }}'
+    {% if sonar_config_file -%}
+    - '-Dproject.settings={{ git_local_path }}/{{ sonar_config_file }}'
+    {% else -%}
+    - '-Dsonar.projectKey={{ sonar_cloud_project_key }}'
+    {%- endif %}
+    - '-Dsonar.projectBaseDir={{ git_local_path }}'
+    - '-Dsonar.branch.name={{ git_checkout_target }}'
+    - '-Dsonar.go.coverage.reportPaths={{ coverage_file }}'
+    - '-Dsonar.qualitygate.wait=true'
+    - '-Dsonar.verbose={{ sonar_verbose_log }}'

--- a/pipeline-modules/common/aws/git-clone.yaml
+++ b/pipeline-modules/common/aws/git-clone.yaml
@@ -36,4 +36,3 @@ template: |
     build:
       commands:
         - git-clone.sh {{ git_remote_path }} {{ git_checkout_target }} {{ git_local_path }}
-        - export sha_tag=$(git -C {{ git_local_path }} log --format="%H" -n 1);

--- a/pipeline-modules/common/azure/git-clone.yaml
+++ b/pipeline-modules/common/azure/git-clone.yaml
@@ -34,5 +34,4 @@ template: |
   steps:
   - script: |
       git-clone.sh {{ git_remote_path }} {{ git_checkout_target }} {{ git_local_path }}
-      echo "##vso[task.setvariable variable=sha_tag]$(git -C {{ git_local_path }} log --format="%H" -n 1)"
     displayName: 'Git Clone'


### PR DESCRIPTION
Added sonarcloud.yaml and go-unittest.yaml for app integration
pipelines.
   
If the unittest modules is in the pipeline before the sonarcloud
module, then the test coverage information will be passed to
SonarCloud.
    
Also for GCP, switched the go-build module from using the cloud-
builders go image to the standard golang image. The support for
the cloud-builders image seems to be dropping as it is slow to
adopt new versions of golang.
    
As the sha_tag is now being passed in from the services, the places
where it was being exported as an env var have been removed.
