### PR TITLE
VAN-3614 Add pnpm to CI checks and fix npm checks

### DIFF
--- a/pipeline-modules/app-service/gcp/node-build.yaml
+++ b/pipeline-modules/app-service/gcp/node-build.yaml
@@ -10,6 +10,7 @@ keywords:
   - Node.js
   - NPM
   - Yarn
+  - PNPM
   - Install
   - Build
 author: CloudCover
@@ -18,12 +19,14 @@ inputs:
   properties:
     package_manager:
       title: Package manager
-      description: Your package manager, either node or yarn
+      description: "Your package manager: npm, pnpm, yarn or node"
       type: string
-      default: node
+      default: npm
       enum:
-        - node
+        - npm
         - yarn
+        - pnpm
+        - node
     npm_build_args:
       title: Package manager arguments
       description: Arguments for your Package manager command
@@ -41,16 +44,27 @@ inputs:
       description: The version of Node.js being used (From https://hub.docker.com/_/node/)
       type: string
       default: 18.12.0-alpine
+    package_manager_version:
+      title: Package manager version
+      description: The version of package manager being used
+      type: string
+      default: latest
   # For some reason required fields with default value is not allowed, this needs to be fixed before we uncomment the below fields
   # required:
   #   - package_manager
   #   - npm_build_args
 template: |
   steps:
-  {% for arg in npm_build_args %}
-  - id: '{{ package_manager }} {{ arg }}'
+  - id: 'Node Build'
     name: node:{{ node_js_version }}
-    entrypoint: {{ package_manager }}
-    args: ['{{ arg }}']
+    script: |
+      {% if package_manager == 'pnpm' %}
+        corepack enable && corepack prepare pnpm@{{ package_manager_version }} --activate
+      {% elif package_manager == 'yarn' %}
+        corepack enable && corepack prepare yarn@{{ package_manager_version }} --activate
+      {% endif %}
+
+      {% for arg in npm_build_args %}
+        {{ package_manager }} {{ arg }}
+      {% endfor %}
     dir: {{ working_dir }}
-  {% endfor %}


### PR DESCRIPTION
We switched to pnpm for Stance and Codepipes but didn't update it in our CI-CD modules. I had to redo how the script works because Google cloud doesn't share state between steps. Now the whole thing runs as a single script.
