### PR TITLE
VAN-2954 Rollout restart the pod on every deployment to get the updated change of Configmap & secrets

### DIFF
--- a/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
+++ b/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
@@ -303,6 +303,8 @@ template: |
           printf '  %s: %s\n' "$name" "$value" >> values.yaml
           done;
         - helm upgrade --install -f values.yaml {{applicationName}}-{{environment}} . --atomic --timeout {{deployment_timeout}}
+        - kubectl rollout restart deployment {{applicationName}}-deployment -n {{applicationName}}
+        - kubectl rollout status deployment {{applicationName}}-deployment   -n {{applicationName}}
 
     post_build:
       commands:

--- a/pipeline-modules/deployment-service/aws/istio-eks-module.yaml
+++ b/pipeline-modules/deployment-service/aws/istio-eks-module.yaml
@@ -452,6 +452,8 @@ template: |
           done; 
   
         - helm upgrade --install -f values.yaml {{applicationName}}-{{environment}} . #--atomic --timeout {{deployment_timeout}}
+        - kubectl rollout restart deployment {{applicationName}}-deployment -n {{applicationName}}
+        - kubectl rollout status deployment {{applicationName}}-deployment   -n {{applicationName}}
 
       {% else %}
         - helm list 

--- a/pipeline-modules/deployment-service/azure/basic-aks-module.yaml
+++ b/pipeline-modules/deployment-service/azure/basic-aks-module.yaml
@@ -262,6 +262,9 @@ template: |
     - script: |
             cd {{helm_chart_path}} ;
             helm upgrade --install -f values.yaml {{applicationName}}-{{environment}} . --atomic --timeout {{deployment_timeout}}
+            kubectl rollout restart deployment {{applicationName}}-deployment -n {{applicationName}}
+            kubectl rollout status deployment {{applicationName}}-deployment   -n {{applicationName}}
+
       displayName: "Helm Deploy {{applicationName}}"
       workingDirectory: {{ workingDir }}
     {% if ports %}

--- a/pipeline-modules/deployment-service/azure/istio-aks-module.yaml
+++ b/pipeline-modules/deployment-service/azure/istio-aks-module.yaml
@@ -464,6 +464,9 @@ template: |
             ls -la;
             cat values.yaml;
             helm upgrade --install -f values.yaml {{applicationName}}-{{environment}} . #--atomic --timeout {{deployment_timeout}}
+            kubectl rollout restart deployment {{applicationName}}-deployment -n {{applicationName}}
+            kubectl rollout status deployment {{applicationName}}-deployment   -n {{applicationName}}
+
       displayName: "Helm Deploy {{applicationName}}"
       workingDirectory: {{ workingDir }}
     {% else %}

--- a/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
@@ -274,6 +274,8 @@ template: |
     - |
       cd {{helm_chart_path}} ;
       helm upgrade --install -f values.yaml {{applicationName}}-{{environment}} . --atomic --timeout {{deployment_timeout}}
+      kubectl rollout restart deployment {{applicationName}}-deployment -n {{applicationName}}
+      kubectl rollout status deployment {{applicationName}}-deployment   -n {{applicationName}}
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
     args:

--- a/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
@@ -496,6 +496,8 @@ template: |
     - |
       cd {{helm_chart_path}} ;
       helm upgrade --install -f values.yaml {{applicationName}}-{{environment}} . --atomic --timeout {{deployment_timeout}}
+      kubectl rollout restart deployment {{applicationName}}-deployment -n {{applicationName}}
+      kubectl rollout status deployment {{applicationName}}-deployment   -n {{applicationName}}
   - id: 'Extract summary vars'
     name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'


### PR DESCRIPTION
**Known issue  on k8s:**
If we made changes in existing code-pipes variable or added new variable & redeploy the application. The new variable deployed & updated on k8s cluster  as secrets & configmap, but Pod needs manual restart to use that secretes & configmap.

**Resolution :**  
Run the Helm upgrade command to apply the changes.

Use the helm upgrade command to update the deployment with the new Helm chart.

This will create a new Kubernetes deployment with the updated secrets and config maps.

Wait for the pods to restart.

Once the Helm upgrade command completes, Kubernetes will begin to restart the pods one-by-one with zero down type with below command : 

```
kubectl rollout restart deployment {{applicationName}}-deployment -n {{applicationName}}         
kubectl rollout status deployment {{applicationName}}-deployment   -n {{applicationName}}
```

By using a rolling update strategy in your Helm chart, Kubernetes  rollout restart command will automatically replace pods with new ones that have the updated secrets and config maps with zero down time. This will ensure that your pods are using the latest secrets and config maps without the need for manual intervention.