### PR TITLE
VAN-3784 Automate process to push module containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ COMMIT := $(shell git log --format="%H" -n 1)
 
 DOTENV_FILE = .env
 GO_BIN_DIR := $(shell go env GOPATH|cut -d ":" -f 1)/bin
+CPU_ARCH := $(shell go env GOARCH)
 
 GODOTENV := $(shell which $(GO_BIN_DIR)/godotenv)
 ifeq (${GODOTENV},)
@@ -51,6 +52,10 @@ cloud-builders:
 
 .PHONY: push-module-containers
 push-module-containers:
+ifeq (${CPU_ARCH},amd64)
 	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/p0k3r4s4
 	gcloud auth configure-docker
-	cd scripts && ./container-load.sh
+	cd scripts/container-load && ./container-load.sh
+else
+	@echo "This target must be run from amd64 architecture - current is $(CPU_ARCH)"
+endif

--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,9 @@ cloud-builders:
 		echo "=== Building container for $${builder} as ${CLOUD_BUILDER_REPOBASE}${CLOUD_BUILDER_REPO_PREFIX}$${builder}" ; \
 		docker buildx build --push --platform ${CLOUD_BUILDER_PLATFORMS} -t ${CLOUD_BUILDER_REPOBASE}${CLOUD_BUILDER_REPO_PREFIX}$${builder}:${COMMIT} ${CLOUD_BUILDERS_TAG} ${CLOUD_BUILDERS_DIR}/$${builder} ; \
 	done
+
+.PHONY: push-module-containers
+push-module-containers:
+	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/p0k3r4s4
+	gcloud auth configure-docker
+	cd scripts && ./container-load.sh

--- a/scripts/container-load/README.md
+++ b/scripts/container-load/README.md
@@ -1,6 +1,6 @@
 ## Container Image loader
 
-This script pulls container images from one registry (say DockerHub) and pushes them up to 1 or more other registries (likely CldCvr registries on cloud). This is so that we can have local hostiing of images in our cloud accounts.
+This script pulls container images from one registry (say DockerHub) and pushes them up to 1 or more other registries (likely CldCvr registries on cloud). This is so that we can have local hosting of images in our cloud accounts.
 
 The script processes a manifest file - container-manifest.yaml - This contains the list of registries to push to (ECR/GCR) and the images to process. e.g.:
 

--- a/scripts/container-load/README.md
+++ b/scripts/container-load/README.md
@@ -1,0 +1,39 @@
+## Container Image loader
+
+This script pulls container images from one registry (say DockerHub) and pushes them up to 1 or more other registries (likely CldCvr registries on cloud). This is so that we can have local hostiing of images in our cloud accounts.
+
+The script processes a manifest file - container-manifest.yaml - This contains the list of registries to push to (ECR/GCR) and the images to process. e.g.:
+
+```
+registries:
+  - public.ecr.aws/p0k3r4s4
+  - gcr.io/codepipes-staging
+
+images:
+  - name: sonarsource/sonar-scanner-cli
+    tag: latest
+    target_name: sonar-scanner-cli
+```
+
+This will push the DockerHub image sonar-scanner-cli up to ECR and GCR with tag latest.
+
+Requirements:
+
+- yq needs to be installed (https://github.com/mikefarah/yq/#install)
+- You need to be signed into all registries listed in the manifest file and have write permissions to them.
+- For AWS ECR, the image repo needs to be pre-created (can use AWS console)
+- If you want to avoid any rate limit issues, you should sign into DH as well
+
+Running the script:
+
+```
+$ scripts/container-load > ./container-load.sh
+```
+
+There is also a make target for ease of use:
+
+```
+$ make push-module-containers
+```
+
+The make target will also attempt to login to ECR and GCR using local credentials.

--- a/scripts/container-load/README.md
+++ b/scripts/container-load/README.md
@@ -11,11 +11,11 @@ registries:
 
 images:
   - name: sonarsource/sonar-scanner-cli
-    tag: latest
+    tags: [latest, 4, 4.8]
     target_name: sonar-scanner-cli
 ```
 
-This will push the DockerHub image sonar-scanner-cli up to ECR and GCR with tag latest.
+This will push the DockerHub image sonar-scanner-cli up to ECR and GCR with tag latest, 4 and 4.8.
 
 Requirements:
 
@@ -27,7 +27,7 @@ Requirements:
 Running the script:
 
 ```
-$ scripts/container-load > ./container-load.sh
+$ scripts/container-load> ./container-load.sh
 ```
 
 There is also a make target for ease of use:
@@ -37,3 +37,4 @@ $ make push-module-containers
 ```
 
 The make target will also attempt to login to ECR and GCR using local credentials.
+NOTE: This make target will fail with a message if not run from an environment based of amd64 CPU architecture.

--- a/scripts/container-load/container-load.sh
+++ b/scripts/container-load/container-load.sh
@@ -8,14 +8,20 @@ image_cnt=$(yq '.images|length' < $MANIFEST_FILE)
 
 for ((i=0;i<$image_cnt;i++)); do
     image_name=$(yq ".images.[$i].name" < $MANIFEST_FILE)
-    image_tag=$(yq ".images.[$i].tag" < $MANIFEST_FILE)
-    echo "=== Pulling image $image_name:$image_tag"
-    docker pull $image_name:$image_tag
-    
-    for registry in $(yq -o p '.registries' < container-manifest.yaml |cut -d ' ' -f 3) ; do
+    tag_cnt=$(yq ".images.[$i].tags|length" < $MANIFEST_FILE)
+    for ((t=0;t<$tag_cnt;t++)); do
+        image_tag=$(yq ".images.[$i].tags[$t]" < $MANIFEST_FILE)
+        echo "=== Pulling image $image_name:$image_tag"
+        docker pull $image_name:$image_tag
+    done
+
+    for registry in $(yq -o p '.registries' < $MANIFEST_FILE |cut -d ' ' -f 3) ; do
         echo "=== Tagging and uploading to $registry"
         image_target=$(yq ".images.[$i].target_name" < $MANIFEST_FILE)
-        docker tag $image_name:$image_tag "$registry/$image_target:$image_tag"
-        docker push "$registry/$image_target:$image_tag"
+        for ((t=0;t<$tag_cnt;t++)); do
+            image_tag=$(yq ".images.[$i].tags[$t]" < $MANIFEST_FILE)
+            docker tag $image_name:$image_tag "$registry/$image_target:$image_tag"
+        done
+        docker push "$registry/$image_target" --all-tags
     done
 done

--- a/scripts/container-load/container-load.sh
+++ b/scripts/container-load/container-load.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# see README.md for doc
+set -e
+
+MANIFEST_FILE=container-manifest.yaml
+
+image_cnt=$(yq '.images|length' < $MANIFEST_FILE)
+
+for ((i=0;i<$image_cnt;i++)); do
+    image_name=$(yq ".images.[$i].name" < $MANIFEST_FILE)
+    image_tag=$(yq ".images.[$i].tag" < $MANIFEST_FILE)
+    echo "=== Pulling image $image_name:$image_tag"
+    docker pull $image_name:$image_tag
+    
+    for registry in $(yq -o p '.registries' < container-manifest.yaml |cut -d ' ' -f 3) ; do
+        echo "=== Tagging and uploading to $registry"
+        image_target=$(yq ".images.[$i].target_name" < $MANIFEST_FILE)
+        docker tag $image_name:$image_tag "$registry/$image_target:$image_tag"
+        docker push "$registry/$image_target:$image_tag"
+    done
+done

--- a/scripts/container-load/container-manifest.yaml
+++ b/scripts/container-load/container-manifest.yaml
@@ -1,0 +1,8 @@
+registries:
+  - public.ecr.aws/p0k3r4s4
+  - gcr.io/codepipes-staging
+
+images:
+  - name: sonarsource/sonar-scanner-cli
+    tag: latest
+    target_name: sonar-scanner-cli

--- a/scripts/container-load/container-manifest.yaml
+++ b/scripts/container-load/container-manifest.yaml
@@ -4,5 +4,11 @@ registries:
 
 images:
   - name: sonarsource/sonar-scanner-cli
-    tag: latest
+    tags: [latest, 4, 4.8]
     target_name: sonar-scanner-cli
+  - name: alpine
+    tags: [latest]
+    target_name: alpine
+  - name: golang
+    tags: [1.17-alpine]
+    target_name: golang


### PR DESCRIPTION
In order to avoid rate limiting issues with anonymous connections
to certain Docker registries, we will be hosting any images required
by our pipeline modules in ECR or GCR (maybe ACR in the future).

This introduces a shell script that pulls the relevant images, tags
them appropriately and pushes them up to ECR/GCR. The relevant images
are listed in a container-manifest.yaml file that is processed by
the script.

Also added a make target that logs into the various registries and
runs the script.
