### PR TITLE
VAN-3814 Fix create-env-file.sh missing param failure

### DIFF
--- a/assets/scripts/create-env-file.sh
+++ b/assets/scripts/create-env-file.sh
@@ -2,7 +2,7 @@
 set -e
 sn=`basename $0`
 
-[ $# -lt 2 ] && echo "$0: must supply at least 2 parameters - env_file_name, <list of exported variables>" && exit 1
+[ $# -lt 2 ] && echo "$0: less than 2 input parameters provided - skipping env file creation for $@" exit 0
 
 ENV_FILE_NAME=$1
 shift


### PR DESCRIPTION
In cases where the script is called with an insufficient number
of input params, it will now print a message and exit normally.
The usual case of this occurs when there are no env vars or secret
env vars present in the pipeline.
