### PR TITLE
VAN-3906 Fix CGO_ENABLED variable for GCP go modules

### DIFF
--- a/pipeline-modules/app-service/gcp/go-build.yaml
+++ b/pipeline-modules/app-service/gcp/go-build.yaml
@@ -38,11 +38,12 @@ template: |
   - id: 'Go Build'
     name: golang:{{ go_version }}
     dir: {{ working_dir }}
-    env: ["GOPATH=/workspace", "CGO_ENABLED=${CGO_ENABLED:-0}"]
+    env: ["GOPATH=/workspace"]
     entrypoint: /bin/bash
     args:
       - -c
       - |
         set -x
+        export CGO_ENABLED=$${CGO_ENABLED:-0}
         go version
         go build -v {% for arg in go_build_args %} {{ arg }} {% endfor %}

--- a/pipeline-modules/app-service/gcp/go-unittest.yaml
+++ b/pipeline-modules/app-service/gcp/go-unittest.yaml
@@ -43,10 +43,11 @@ template: |
   - id: go_unittest
     name: golang:{{ go_version }}
     dir: {{ working_dir }}
-    env: ["GOPATH=/workspace", "CGO_ENABLED=${CGO_ENABLED:-0}"]
+    env: ["GOPATH=/workspace"]
     entrypoint: /bin/bash
     args:
       - -c
       - |
         set -x
+        export CGO_ENABLED=$${CGO_ENABLED:-0}
         go test -v -coverprofile={{ coverage_file }} -coverpkg ./... {% for arg in go_test_args %} {{ arg }} {% endfor %} ./...


### PR DESCRIPTION
The CGO_ENABLED variable needs to be exported in the pipeline
script instead of in the env: section.
