### PR TITLE
VAN-3989 Update the Sonar scanner module for GCP

### DIFF
--- a/pipeline-modules/app-service/gcp/sonarcloud.yaml
+++ b/pipeline-modules/app-service/gcp/sonarcloud.yaml
@@ -76,7 +76,7 @@ template: |
     - |
       export SONAR_TOKEN={{sonar_cloud_login_token}}
       echo "Webhook Event event_type : $$event_type"
-
+      set -x
       if [ "$$event_type" == "pull_request" ]; then
       echo "Sonar analysis type: Pull request"
       echo "PR Number: $$git_pr_key"

--- a/pipeline-modules/app-service/gcp/sonarcloud.yaml
+++ b/pipeline-modules/app-service/gcp/sonarcloud.yaml
@@ -17,6 +17,11 @@ inputs:
       description: Git branch, tag or commit hash to checkout.
       type: string
       default: ""
+    project_base_directory:
+      title: Project Folder
+      description: Project Base directory where sonar-scanner will run
+      type: string
+      default: "." 
     sonar_cloud_url:
       title: SonarCloud URL
       description: URL for SonarCloud endpoint
@@ -89,11 +94,12 @@ template: |
     - |
       export SONAR_TOKEN={{sonar_cloud_login_token}}
       {% if event_type == 'Branch' %}
-      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir=. -Dsonar.branch.name={{ git_checkout_target }} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }}
+      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir={{project_base_directory}} -Dsonar.branch.name={{ git_checkout_target }} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }}
       {% endif %}
 
       {% if event_type == 'PR' %}
       export PR_NUMBER=$(git ls-remote |grep '{{sha_tag}}'|awk '/refs\/pull\/.*\/./{split($2,a,"/");print a[3]}')
       echo "PR Number: $$PR_NUMBER"
-      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir=. -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }} -Dsonar.pullrequest.key=$$PR_NUMBER -Dsonar.pullrequest.branch={{ git_checkout_target }} -Dsonar.pullrequest.base={{sonar_pullrequest_base}}
+      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir={{project_base_directory}} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }} -Dsonar.pullrequest.key=$$PR_NUMBER -Dsonar.pullrequest.branch={{ git_checkout_target }} -Dsonar.pullrequest.base={{sonar_pullrequest_base}}
       {% endif %}
+

--- a/pipeline-modules/app-service/gcp/sonarcloud.yaml
+++ b/pipeline-modules/app-service/gcp/sonarcloud.yaml
@@ -55,8 +55,31 @@ inputs:
       description: Unit test coverage file to be analyzed by SonarCloud
       type: string
       default: "coverage.out"
+    event_type:
+      title: Sonar Run on
+      description: Choose option from Branch or PR on which sonar scan will run.
+      type: string
+      default: Branch
+      enum:
+        - Branch
+        - PR
+    sonar_pullrequest_base:
+      title: Sonar pullrequest base branch
+      description: Here define the base branch from which created your PR. This value only required when Sonar Run on PR
+      type: string
+      default: "main"        
+    sha_tag:
+      title: SHA Git commit tag
+      description: Resloved Commit hash for Input git artifact
+      type: string 
+    pr_number:
+      title: PR Number ID
+      description: Enter PR number ID
+      type: string
+      default: "99"                        
   internal:
     - git_checkout_target
+    - sha_tag
   required:
     - sonar_cloud_login_token
     - sonar_cloud_org
@@ -68,5 +91,10 @@ template: |
     args:
     - '-c'
     - |
-      export SONAR_TOKEN={{sonar_cloud_login_token}} 
-      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ git_local_path }}/{{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir={{ git_local_path }} -Dsonar.branch.name={{ git_checkout_target }} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }} 
+      export SONAR_TOKEN={{sonar_cloud_login_token}}
+      {% if event_type == 'Branch' %}
+      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ git_local_path }}/{{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir={{ git_local_path }} -Dsonar.branch.name={{ git_checkout_target }} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }}
+      {% endif %}
+      {% if event_type == 'PR' %}
+      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ git_local_path }}/{{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir={{ git_local_path }} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }} -Dsonar.pullrequest.key={{pr_number}} -Dsonar.pullrequest.branch={{ git_checkout_target }} -Dsonar.pullrequest.base={{sonar_pullrequest_base}}
+      {% endif %}

--- a/pipeline-modules/app-service/gcp/sonarcloud.yaml
+++ b/pipeline-modules/app-service/gcp/sonarcloud.yaml
@@ -64,18 +64,9 @@ template: |
   steps:
   - id: 'Run scan on SonarCloud'
     name: gcr.io/codepipes-staging/sonar-scanner-cli
+    entrypoint: 'bash'
     args:
-    - 'sonar-scanner'
-    - '-Dsonar.host.url={{ sonar_cloud_url }}'
-    - '-Dsonar.login={{ sonar_cloud_login_token }}'
-    - '-Dsonar.organization={{ sonar_cloud_org }}'
-    {% if sonar_config_file -%}
-    - '-Dproject.settings={{ git_local_path }}/{{ sonar_config_file }}'
-    {% else -%}
-    - '-Dsonar.projectKey={{ sonar_cloud_project_key }}'
-    {%- endif %}
-    - '-Dsonar.projectBaseDir={{ git_local_path }}'
-    - '-Dsonar.branch.name={{ git_checkout_target }}'
-    - '-Dsonar.go.coverage.reportPaths={{ coverage_file }}'
-    - '-Dsonar.qualitygate.wait=true'
-    - '-Dsonar.verbose={{ sonar_verbose_log }}'
+    - '-c'
+    - |
+      export SONAR_TOKEN={{sonar_cloud_login_token}} 
+      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ git_local_path }}/{{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir={{ git_local_path }} -Dsonar.branch.name={{ git_checkout_target }} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }} 

--- a/pipeline-modules/app-service/gcp/sonarcloud.yaml
+++ b/pipeline-modules/app-service/gcp/sonarcloud.yaml
@@ -54,42 +54,14 @@ inputs:
       title: Code Coverage file
       description: Unit test coverage file to be analyzed by SonarCloud
       type: string
-      default: "coverage.out"
-    analysis_type:
-      title: SonarQube analysis on
-      description: Choose option for SonarQube analysis on Branch or PR .
-      type: string
-      default: PR
-      enum:
-        - Branch
-        - PR       
+      default: "coverage.out"    
     working_dir:
       title: Working directory
       description: The current working directory to execute command
-      type: string
-    event_type:
-      title: Webhook Event type
-      description: Webhook Event type pull_request or push.
-      type: string
-    pr_number:
-      title: Pull request Number
-      description: Pull request Number
-      type: string 
-    base_branch:
-      title: Pull request Base Branch
-      description: Pull request Base Branch from  where PR has been created.
-      type: string 
-    pull_req_branch:
-      title: Pull request Branch
-      description: Pull request branch
-      type: string                                                     
+      type: string                                                   
   internal:
     - git_checkout_target
     - working_dir
-    - event_type
-    - pr_number
-    - base_branch
-    - pull_req_branch     
   required:
     - sonar_cloud_login_token
     - sonar_cloud_org
@@ -103,17 +75,16 @@ template: |
     - '-c'
     - |
       export SONAR_TOKEN={{sonar_cloud_login_token}}
-      echo "event_type : {{event_type}}"
-      {% if event_type=='push'  %}
+      echo "Webhook Event event_type : $$event_type"
+
+      if [ "$$event_type" == "pull_request" ]; then
+      echo "Sonar analysis type: Pull request"
+      echo "PR Number: $$git_pr_key"
+      echo "PR Base Branch: $$git_pr_base"
+      echo "PR Branch: $$git_pr_head"
+      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir={{project_base_directory}} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }} -Dsonar.pullrequest.key=$$git_pr_key -Dsonar.pullrequest.branch=$$git_pr_head -Dsonar.pullrequest.base=$$git_pr_base
+      
+      else
       echo "Sonar analysis type: Branch"
       sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir={{project_base_directory}} -Dsonar.branch.name={{ git_checkout_target }} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }}
-      {% endif %}
-
-      {% if event_type=='pull_request'  %}
-      echo "Sonar analysis type: Pull request"
-      echo "PR Number: {{pr_number}}"
-      echo "PR : {{base_branch}}"
-      echo "PR Branch: {{pull_req_branch}}"
-      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir={{project_base_directory}} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }} -Dsonar.pullrequest.key={{pr_number}} -Dsonar.pullrequest.branch={{pull_req_branch}} -Dsonar.pullrequest.base={{base_branch}}
-      {% endif %}
-
+      fi

--- a/pipeline-modules/app-service/gcp/sonarcloud.yaml
+++ b/pipeline-modules/app-service/gcp/sonarcloud.yaml
@@ -60,7 +60,7 @@ inputs:
         - PR
     sonar_pullrequest_base:
       title: Sonar pull request base branch
-      description: Here define the base branch from which created your PR. This value only required when Sonar Run on PR
+      description: Here define the base branch from which created your PR. This value only required when SonarQube analysis on on PR
       type: string
       default: "main"        
     sha_tag:

--- a/pipeline-modules/app-service/gcp/sonarcloud.yaml
+++ b/pipeline-modules/app-service/gcp/sonarcloud.yaml
@@ -51,8 +51,8 @@ inputs:
       type: string
       default: "coverage.out"
     event_type:
-      title: Sonar Run on
-      description: Choose option from Branch or PR on which sonar scan will run.
+      title: SonarQube analysis on
+      description: Choose option for SonarQube analysis on Branch or PR .
       type: string
       default: PR
       enum:
@@ -91,7 +91,7 @@ template: |
       {% if event_type == 'Branch' %}
       sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir=. -Dsonar.branch.name={{ git_checkout_target }} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }}
       {% endif %}
-      
+
       {% if event_type == 'PR' %}
       export PR_NUMBER=$(git ls-remote |grep '{{sha_tag}}'|awk '/refs\/pull\/.*\/./{split($2,a,"/");print a[3]}')
       echo "PR Number: $$PR_NUMBER"

--- a/pipeline-modules/app-service/gcp/sonarcloud.yaml
+++ b/pipeline-modules/app-service/gcp/sonarcloud.yaml
@@ -91,8 +91,8 @@ template: |
       {% if event_type == 'Branch' %}
       sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir=. -Dsonar.branch.name={{ git_checkout_target }} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }}
       {% endif %}
+      
       {% if event_type == 'PR' %}
-
       export PR_NUMBER=$(git ls-remote |grep '{{sha_tag}}'|awk '/refs\/pull\/.*\/./{split($2,a,"/");print a[3]}')
       echo "PR Number: $$PR_NUMBER"
       sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir=. -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }} -Dsonar.pullrequest.key=$$PR_NUMBER -Dsonar.pullrequest.branch={{ git_checkout_target }} -Dsonar.pullrequest.base={{sonar_pullrequest_base}}

--- a/pipeline-modules/app-service/gcp/sonarcloud.yaml
+++ b/pipeline-modules/app-service/gcp/sonarcloud.yaml
@@ -17,11 +17,6 @@ inputs:
       description: Git branch, tag or commit hash to checkout.
       type: string
       default: ""
-    git_local_path:
-      title: Local Clone Directory
-      description: The name of a new directory to clone into.
-      type: string
-      default: repo
     sonar_cloud_url:
       title: SonarCloud URL
       description: URL for SonarCloud endpoint
@@ -59,12 +54,12 @@ inputs:
       title: Sonar Run on
       description: Choose option from Branch or PR on which sonar scan will run.
       type: string
-      default: Branch
+      default: PR
       enum:
         - Branch
         - PR
     sonar_pullrequest_base:
-      title: Sonar pullrequest base branch
+      title: Sonar pull request base branch
       description: Here define the base branch from which created your PR. This value only required when Sonar Run on PR
       type: string
       default: "main"        
@@ -72,14 +67,14 @@ inputs:
       title: SHA Git commit tag
       description: Resloved Commit hash for Input git artifact
       type: string 
-    pr_number:
-      title: PR Number ID
-      description: Enter PR number ID
-      type: string
-      default: "99"                        
+    working_dir:
+      title: Working directory
+      description: The current working directory to execute command
+      type: string                            
   internal:
     - git_checkout_target
     - sha_tag
+    - working_dir    
   required:
     - sonar_cloud_login_token
     - sonar_cloud_org
@@ -88,13 +83,17 @@ template: |
   - id: 'Run scan on SonarCloud'
     name: gcr.io/codepipes-staging/sonar-scanner-cli
     entrypoint: 'bash'
+    dir: {{ working_dir }}
     args:
     - '-c'
     - |
       export SONAR_TOKEN={{sonar_cloud_login_token}}
       {% if event_type == 'Branch' %}
-      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ git_local_path }}/{{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir={{ git_local_path }} -Dsonar.branch.name={{ git_checkout_target }} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }}
+      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir=. -Dsonar.branch.name={{ git_checkout_target }} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }}
       {% endif %}
       {% if event_type == 'PR' %}
-      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ git_local_path }}/{{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir={{ git_local_path }} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }} -Dsonar.pullrequest.key={{pr_number}} -Dsonar.pullrequest.branch={{ git_checkout_target }} -Dsonar.pullrequest.base={{sonar_pullrequest_base}}
+
+      export PR_NUMBER=$(git ls-remote |grep '{{sha_tag}}'|awk '/refs\/pull\/.*\/./{split($2,a,"/");print a[3]}')
+      echo "PR Number: $$PR_NUMBER"
+      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir=. -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }} -Dsonar.pullrequest.key=$$PR_NUMBER -Dsonar.pullrequest.branch={{ git_checkout_target }} -Dsonar.pullrequest.base={{sonar_pullrequest_base}}
       {% endif %}

--- a/pipeline-modules/app-service/gcp/sonarcloud.yaml
+++ b/pipeline-modules/app-service/gcp/sonarcloud.yaml
@@ -55,31 +55,41 @@ inputs:
       description: Unit test coverage file to be analyzed by SonarCloud
       type: string
       default: "coverage.out"
-    event_type:
+    analysis_type:
       title: SonarQube analysis on
       description: Choose option for SonarQube analysis on Branch or PR .
       type: string
       default: PR
       enum:
         - Branch
-        - PR
-    sonar_pullrequest_base:
-      title: Sonar pull request base branch
-      description: Here define the base branch from which created your PR. This value only required when SonarQube analysis on on PR
-      type: string
-      default: "main"        
-    sha_tag:
-      title: SHA Git commit tag
-      description: Resloved Commit hash for Input git artifact
-      type: string 
+        - PR       
     working_dir:
       title: Working directory
       description: The current working directory to execute command
-      type: string                            
+      type: string
+    event_type:
+      title: Webhook Event type
+      description: Webhook Event type pull_request or push.
+      type: string
+    pr_number:
+      title: Pull request Number
+      description: Pull request Number
+      type: string 
+    base_branch:
+      title: Pull request Base Branch
+      description: Pull request Base Branch from  where PR has been created.
+      type: string 
+    pull_req_branch:
+      title: Pull request Branch
+      description: Pull request branch
+      type: string                                                     
   internal:
     - git_checkout_target
-    - sha_tag
-    - working_dir    
+    - working_dir
+    - event_type
+    - pr_number
+    - base_branch
+    - pull_req_branch     
   required:
     - sonar_cloud_login_token
     - sonar_cloud_org
@@ -93,13 +103,17 @@ template: |
     - '-c'
     - |
       export SONAR_TOKEN={{sonar_cloud_login_token}}
-      {% if event_type == 'Branch' %}
+      echo "event_type : {{event_type}}"
+      {% if event_type=='push'  %}
+      echo "Sonar analysis type: Branch"
       sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir={{project_base_directory}} -Dsonar.branch.name={{ git_checkout_target }} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }}
       {% endif %}
 
-      {% if event_type == 'PR' %}
-      export PR_NUMBER=$(git ls-remote |grep '{{sha_tag}}'|awk '/refs\/pull\/.*\/./{split($2,a,"/");print a[3]}')
-      echo "PR Number: $$PR_NUMBER"
-      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir={{project_base_directory}} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }} -Dsonar.pullrequest.key=$$PR_NUMBER -Dsonar.pullrequest.branch={{ git_checkout_target }} -Dsonar.pullrequest.base={{sonar_pullrequest_base}}
+      {% if event_type=='pull_request'  %}
+      echo "Sonar analysis type: Pull request"
+      echo "PR Number: {{pr_number}}"
+      echo "PR : {{base_branch}}"
+      echo "PR Branch: {{pull_req_branch}}"
+      sonar-scanner -Dsonar.host.url={{ sonar_cloud_url }} -Dsonar.organization={{ sonar_cloud_org }} {% if sonar_config_file -%} -Dproject.settings={{ sonar_config_file }} {% else -%} -Dsonar.projectKey={{ sonar_cloud_project_key }} {%- endif %} -Dsonar.projectBaseDir={{project_base_directory}} -Dsonar.go.coverage.reportPaths={{ coverage_file }} -Dsonar.qualitygate.wait=true -Dsonar.verbose={{ sonar_verbose_log }} -Dsonar.pullrequest.key={{pr_number}} -Dsonar.pullrequest.branch={{pull_req_branch}} -Dsonar.pullrequest.base={{base_branch}}
       {% endif %}
 


### PR DESCRIPTION
**Issue** :  When passing the sonar key as a Codepipes EVN variable ($$SONAR_KEY), the value is unable to parse this module.

**Fixed** : 

- Now in Sonar module we can pass the SONAR_TOKEN_KEY from  code pipes variables , input just define $$SONAR_TOKEN_KEY for GCP
- Added a new feature can Sonnar scan on Branch & PR  based on Webhook event type.

- Updated the PR to use the value in sonar PR analysis which declared as the environment in the pipeline:
"event_type"
"git_pr_key"
"git_pr_base"
"git_pr_head"







