### PR TITLE
VAN-4039 Add error handling for GCP Docker Compose

### DIFF
--- a/pipeline-modules/app-service/gcp/docker-compose-build.yaml
+++ b/pipeline-modules/app-service/gcp/docker-compose-build.yaml
@@ -56,6 +56,7 @@ template: |
     args:
     - '-c'
     - |
+      set -e
       docker compose build {{ docker_compose_service_name }}
       {% verbatim %}export image_name=$(docker image ls --format "table {{.Repository}}:{{.Tag}}"|head -2 | tail -1){% endverbatim %}
       echo Docker compose created the image: $image_name ......


### PR DESCRIPTION
This commit adds error handling to the `docker-compose-build` Cloud Build module to ensure that the pipeline fails when the `docker compose build` command fails. The module now uses the `set -e` command to achieve this.