### PR TITLE
VAN-4071 fix aws vpc config

### DIFF
--- a/pipeline-modules/common/aws/pipeline-config.yaml
+++ b/pipeline-modules/common/aws/pipeline-config.yaml
@@ -61,7 +61,7 @@ inputs:
       type: object
       default: {}
       properties:
-        securityGroupIds:
+        securitygroupids:
           title: Security Group IDs
           description: "A list of one or more security groups IDs in your Amazon VPC."
           type: array
@@ -75,7 +75,7 @@ inputs:
           default: []
           items:
             type: string
-        vpcId:
+        vpcid:
           title: VPC ID
           description: "The ID of the Amazon VPC."
           type: string
@@ -176,7 +176,7 @@ template: |
     value: "{{ tag_value }}"
   {% endfor %}
   timeoutinminutes: {{ pipeline_run_timeout_min }}
-  {% if (not vpc_config) or vpc_config|length == 0 or vpc_config.vpcId == "" %}
+  {% if (not vpc_config) or vpc_config|length == 0 or vpc_config.vpcid == "" %}
   vpcconfig: null
   {% else %}
   vpcconfig: {{ vpc_config|cpi_json }}

--- a/pipeline-modules/infra-service/aws/pipeline-config.yaml
+++ b/pipeline-modules/infra-service/aws/pipeline-config.yaml
@@ -66,7 +66,7 @@ inputs:
       type: object
       default: {}
       properties:
-        securityGroupIds:
+        securitygroupids:
           title: Security Group IDs
           description: "A list of one or more security groups IDs in your Amazon VPC."
           type: array
@@ -80,7 +80,7 @@ inputs:
           default: []
           items:
             type: string
-        vpcId:
+        vpcid:
           title: VPC ID
           description: "The ID of the Amazon VPC."
           type: string
@@ -153,7 +153,7 @@ template: |
     value: "{{ tag_value }}"
   {% endfor %}
   timeoutinminutes: {{ pipeline_run_timeout_min }}
-  {% if (not vpc_config) or vpc_config|length == 0 or vpc_config.vpcId == "" %}
+  {% if (not vpc_config) or vpc_config|length == 0 or vpc_config.vpcid == "" %}
   vpcconfig: null
   {% else %}
   vpcconfig: {{ vpc_config|cpi_json }}


### PR DESCRIPTION
Because of how go yaml v2 works, it needs all fields in lower case instead of camel case to be able to unmarshal it into the object.

The issue where vpc configuration was not working even after successfully setting it into the yaml, was cause because we had camel-case field names inside the config object. this change fixes it by changing it to lowercase.