### PR TITLE
VAN-4078 Add helm image to build locally

### DIFF
--- a/cloud-builders/helm/Dockerfile
+++ b/cloud-builders/helm/Dockerfile
@@ -1,0 +1,21 @@
+FROM gcr.io/cloud-builders/gcloud
+
+ARG HELM_VERSION=v3.7.0
+ENV HELM_VERSION=$HELM_VERSION
+
+COPY helm.bash /builder/helm.bash
+
+RUN chmod +x /builder/helm.bash && \
+  mkdir -p /builder/helm && \
+  apt-get update && \
+  apt-get install -y curl gettext-base && \
+  curl -SL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -o helm.tar.gz && \
+  tar zxvf helm.tar.gz --strip-components=1 -C /builder/helm linux-amd64 && \
+  rm helm.tar.gz && \
+  apt-get --purge -y autoremove && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/builder/helm/:$PATH
+
+ENTRYPOINT ["/builder/helm.bash"]

--- a/cloud-builders/helm/helm.bash
+++ b/cloud-builders/helm/helm.bash
@@ -1,0 +1,64 @@
+#!/bin/bash -e
+
+# If there is no current context, get one.
+if [[ $(kubectl config current-context 2> /dev/null) == "" && "$SKIP_CLUSTER_CONFIG" != true ]]; then
+    # This tries to read environment variables. If not set, it grabs from gcloud
+    cluster=${CLOUDSDK_CONTAINER_CLUSTER:-$(gcloud config get-value container/cluster 2> /dev/null)}
+    region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2> /dev/null)}
+    zone=${CLOUDSDK_COMPUTE_ZONE:-$(gcloud config get-value compute/zone 2> /dev/null)}
+    project=${GCLOUD_PROJECT:-$(gcloud config get-value core/project 2> /dev/null)}
+
+    function var_usage() {
+        cat <<EOF
+No cluster is set. To set the cluster (and the region/zone where it is found), set the environment variables
+  CLOUDSDK_COMPUTE_REGION=<cluster region> (regional clusters)
+  CLOUDSDK_COMPUTE_ZONE=<cluster zone> (zonal clusters)
+  CLOUDSDK_CONTAINER_CLUSTER=<cluster name>
+EOF
+        exit 1
+    }
+
+    [[ -z "$cluster" ]] && var_usage
+    [ ! "$zone" -o "$region" ] && var_usage
+
+    if [ -n "$region" ]; then
+      echo "Running: gcloud container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
+      gcloud container clusters get-credentials --project="$project" --region="$region" "$cluster"
+    else
+      echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
+      gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster"
+    fi
+fi
+
+# if GCS_PLUGIN_VERSION is set, install the plugin
+if [[ -n $GCS_PLUGIN_VERSION ]]; then
+  echo "Installing helm GCS plugin version $GCS_PLUGIN_VERSION "
+  helm plugin install https://github.com/nouney/helm-gcs --version $GCS_PLUGIN_VERSION
+fi
+
+# if DIFF_PLUGIN_VERSION is set, install the plugin
+if [[ -n $DIFF_PLUGIN_VERSION ]]; then
+  echo "Installing helm DIFF plugin version $DIFF_PLUGIN_VERSION "
+  helm plugin install https://github.com/databus23/helm-diff --version $DIFF_PLUGIN_VERSION
+fi
+
+# if HELMFILE_VERSION is set, install Helmfile
+if [[ -n $HELMFILE_VERSION ]]; then
+  echo "Installing Helmfile version $HELMFILE_VERSION "
+  curl -SsL https://github.com/roboll/helmfile/releases/download/$HELMFILE_VERSION/helmfile_linux_amd64 > helmfile
+  chmod 700 helmfile
+fi
+
+# check if repo values provided then add that repo
+if [[ -n $HELM_REPO_NAME && -n $HELM_REPO_URL ]]; then
+  echo "Adding chart helm repo $HELM_REPO_URL"
+  helm repo add $HELM_REPO_NAME $HELM_REPO_URL
+fi
+
+echo "Running: helm repo update"
+helm repo list && helm repo update || true
+
+if [ "$DEBUG" = true ]; then
+    echo "Running: helm $@"
+fi
+helm "$@"

--- a/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
@@ -136,15 +136,6 @@ template: |
     - '-c'
     - |
       gcloud container clusters get-credentials {{cluster}} --region {{region}}
-  - id: 'Install helm'
-    name: 'gcr.io/cloud-builders/docker'
-    entrypoint: 'bash'
-    args:
-    - '-c'
-    - |
-      git clone https://github.com/GoogleCloudPlatform/cloud-builders-community.git;
-      cd cloud-builders-community/helm;
-      docker build -t gcr.io/$PROJECT_ID/helm:latest . ;
   {% if job_type == 'deploy' %}
   - id: 'Setup helm values'
     name: 'gcr.io/cloud-builders/gcloud'
@@ -255,7 +246,7 @@ template: |
       printf '  %s: %s\n' $name $value >> values.yaml
       done;
   - id: 'Install Application'
-    name: 'gcr.io/$PROJECT_ID/helm'
+    name: 'cldcvr/cpi-helm'
     entrypoint: 'bash'
     args:
     - '-c'
@@ -277,7 +268,7 @@ template: |
       fi
   {% else %}
   - id: 'Uninstall application'
-    name: 'gcr.io/$PROJECT_ID/helm'
+    name: 'cldcvr/cpi-helm'
     entrypoint: 'bash'
     args:
     - '-c'

--- a/pipeline-modules/deployment-service/gcp/basic-helm.yaml
+++ b/pipeline-modules/deployment-service/gcp/basic-helm.yaml
@@ -104,18 +104,9 @@ template: |
     - '-c'
     - |
       gcloud container clusters get-credentials {{cluster}} --region {{region}}
-  - id: 'Install helm'
-    name: 'gcr.io/cloud-builders/docker'
-    entrypoint: 'bash'
-    args:
-    - '-c'
-    - |
-      git clone https://github.com/GoogleCloudPlatform/cloud-builders-community.git;
-      cd cloud-builders-community/helm;
-      docker build -t gcr.io/$PROJECT_ID/helm:latest . ;
   {% if job_type == 'deploy' %}
   - id: 'Install Application'
-    name: 'gcr.io/$PROJECT_ID/helm'
+    name: 'cldcvr/cpi-helm'
     entrypoint: 'bash'
     args:
     - '-c'
@@ -124,13 +115,17 @@ template: |
       kubectl create ns {{namespace}}
       {%- endif %}
       cd {{source_code_path}} ;
+      {%- if helm_values_path != '' %}
+      cp {{helm_values_path}} values_presub.yml
+      cat values_presub.yml | envsubst > {{helm_values_path}}
+      {%- endif %}
       {%- if helm_chart_name != '' %} 
       helm repo add {{helm_chart_repo}} {{helm_chart_url}}
       helm upgrade --install {{service_name}} {{helm_chart_repo}}/{{helm_chart_name}} {%- if helm_chart_version != '' %}--version {{helm_chart_version}}{%- endif %} {%- if helm_values_path != '' %} -f {{helm_values_path}} {%- endif %} --namespace {{namespace}} --atomic --timeout {{deployment_timeout}}
       {%- endif %}
   {% else %}
   - id: 'Uninstall application'
-    name: 'gcr.io/$PROJECT_ID/helm'
+    name: 'cldcvr/cpi-helm'
     entrypoint: 'bash'
     args:
     - '-c'

--- a/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
@@ -307,15 +307,6 @@ template: |
     - '-c'
     - |
       gcloud container clusters get-credentials {{cluster}} --region {{region}}
-  - id: 'Install helm'
-    name: 'gcr.io/cloud-builders/docker'
-    entrypoint: 'bash'
-    args:
-    - '-c'
-    - |
-      git clone https://github.com/GoogleCloudPlatform/cloud-builders-community.git;
-      cd cloud-builders-community/helm;
-      docker build -t gcr.io/$PROJECT_ID/helm:latest . ;
   {% if job_type == 'deploy' %}
   - id: 'Setup helm values'
     name: 'gcr.io/cloud-builders/gcloud'
@@ -477,7 +468,7 @@ template: |
       printf '  %s: %s\n' $name $value >> values.yaml
       done;
   - id: 'Install Application'
-    name: 'gcr.io/$PROJECT_ID/helm'
+    name: 'cldcvr/cpi-helm'
     entrypoint: 'bash'
     args:
     - '-c'
@@ -499,7 +490,7 @@ template: |
       fi
   {% else %}
   - id: 'Uninstall application'
-    name: 'gcr.io/$PROJECT_ID/helm'
+    name: 'cldcvr/cpi-helm'
     entrypoint: 'bash'
     args:
     - '-c'

--- a/pipeline-modules/deployment-service/gcp/private-helm.yaml
+++ b/pipeline-modules/deployment-service/gcp/private-helm.yaml
@@ -94,18 +94,9 @@ template: |
     - '-c'
     - |
       gcloud container clusters get-credentials {{cluster}} --region {{region}}
-  - id: 'Install helm'
-    name: 'gcr.io/cloud-builders/docker'
-    entrypoint: 'bash'
-    args:
-    - '-c'
-    - |
-      git clone https://github.com/GoogleCloudPlatform/cloud-builders-community.git;
-      cd cloud-builders-community/helm;
-      docker build -t gcr.io/$PROJECT_ID/helm:latest . ;
   {% if job_type == 'deploy' %}
   - id: 'Install Application'
-    name: 'gcr.io/$PROJECT_ID/helm'
+    name: 'cldcvr/cpi-helm'
     entrypoint: 'bash'
     args:
     - '-c'
@@ -114,10 +105,14 @@ template: |
       kubectl create ns {{namespace}}
       {% endif %}
       cd {{source_code_path}}/{{helm_chart_path}} ;
+      {%- if helm_values_path != '' %}
+      cp {{source_code_path}}/{{helm_values_path}} values_presub.yml
+      cat values_presub.yml | envsubst > {{source_code_path}}/{{helm_values_path}}
+      {%- endif %}
       helm upgrade --install -f {{source_code_path}}/{{helm_values_path}} {{service_name}} . --atomic --timeout {{deployment_timeout}} --namespace {{namespace}} {% if helm_values_set_var != "" %} --set {{helm_values_set_var}}  {% endif %}
   {% else %}
   - id: 'Uninstall application'
-    name: 'gcr.io/$PROJECT_ID/helm'
+    name: 'cldcvr/cpi-helm'
     entrypoint: 'bash'
     args:
     - '-c'


### PR DESCRIPTION
In order to add "envsubst" as a tool that can be used to preprocess
Helm values.yaml it needs to be in the Helm container used in GCP.
To do this, we need to build the Helm container and push to cldcvr in
Docker Hub.

Changed the relevant deployment templates to use the new cpi-helm
container instead of having each module build it.
Added the preprocessing of values.yaml to replace environment
variables in the basic-helm and private-helm templates.
