### PR TITLE
VAN-4120 fix trimming spaces from env var values

### DIFF
--- a/assets/scripts/create-env-file.sh
+++ b/assets/scripts/create-env-file.sh
@@ -12,7 +12,7 @@ echo "=== ${sn}: Creating ${ENV_FILE_NAME}"
 
 for name in ${EXPORTED_ENV_NAMES}
 do
-    printf "$name=%s\n" "$(eval printf "%s" "\$$name" | jq -aRs .)" >> $ENV_FILE_NAME
+    printf "$name=%s\n" "$(eval printf "%s" "\"\$$name\"" | jq -aRs .)" >> $ENV_FILE_NAME
     printf "Exporting variable '$name'\n"
 done
 


### PR DESCRIPTION
fix create-env-file.sh script to not trim spaces from values