### PR TITLE
VAN-4122 fix sensitive env var handling

### DIFF
--- a/assets/scripts/create-env-file.sh
+++ b/assets/scripts/create-env-file.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+
+##############################################
+# Deprecated Notice - Please Use env.sh Script
+##############################################
+
+# This script is deprecated. Please use env.sh for environment variable management.
+
+# Migration Instructions:
+# - Replace 'cat {{ pipeline_env_file }}' with 'env.sh all --non-secrets --quoted'
+# - Replace 'cat {{ pipeline_secret_file }}' with 'env.sh all --secrets --quoted'
+# - Additional options are available. Run 'env.sh --help' to learn more.
+
 set -e
 sn=`basename $0`
 

--- a/assets/scripts/env.sh
+++ b/assets/scripts/env.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+
+# pre-requisite jq
+bash install-jq.sh > /dev/null 2>&1
+
+# Function to get the value of an environment variable
+get_env_value() {
+    local var_name=$1
+    local var_value=$(printenv "$var_name")
+    printf "%s" "$var_value"
+}
+
+# Function to get the quoted value of an environment variable
+get_quoted_env_value() {
+    local var_name=$1
+    local var_value=$(printenv "$var_name")
+    local quoted_value=$(printf "%s" "$var_value" | jq -aRs .)
+    printf "%s" "$quoted_value"
+}
+
+# Function to loop through and print environment variables using a custom printf template
+print_env_variables_custom() {
+    local secrets=$1
+    local non_secrets=$2
+    local quoted=$3
+    local json_output=$4
+    local template=$5
+
+    local env_names=""
+    if [ "$secrets" = true ]; then
+        env_names="$__VG_EXPORTED_SECRET_ENV_NAMES"
+    elif [ "$non_secrets" = true ]; then
+        env_names="$__VG_EXPORTED_ENV_NAMES"
+    else
+        env_names="$__VG_EXPORTED_ENV_NAMES $__VG_EXPORTED_SECRET_ENV_NAMES"
+    fi
+
+    json_object="{}"
+    for name in $env_names; do
+        local value=$(get_env_value "$name")
+        if [ "$quoted" = true ]; then
+            value=$(get_quoted_env_value "$name")
+        fi
+
+        if [ "$json_output" = true ]; then
+            json_object=$(printf "%s" "$json_object" | jq --arg k "$name" --arg v "$value" '. + {($k): $v}')
+        else
+            printf "$template" "$name" "$value"
+        fi
+    done
+
+    if [ "$json_output" = true ]; then
+        printf "%s\n" "$json_object"
+    fi
+}
+
+# Function to print the script usage instructions
+print_help() {
+    echo "Usage: env.sh <operation> [options]"
+    echo "Operations:"
+    echo "  get <variable name> [--quoted]       : Get the value of the given variable name"
+    echo "  all [options]                        : Loop through and print every environment variable"
+    echo "Options for 'all' operation:"
+    echo "  --secrets                            : Loop through only sensitive environment variables"
+    echo "  --non-secrets                        : Loop through only non-sensitive environment variables"
+    echo "  --quoted                             : Get the value wrapped in quotes for each variable"
+    echo "  --template <printf template>         : Set a custom printf template for printing environment variables"
+    echo "  --json                               : Print environment variables as JSON objects. Cannot be used with `--template` and `--quoted`"
+    echo "  --help                               : Print this help message"
+}
+
+# Check if the script is called with no arguments or the help flag
+if [ "$#" -eq 0 ] || [ "$1" = "--help" ]; then
+    print_help
+    exit 0
+fi
+
+# Parse the command line arguments
+operation=$1
+shift
+
+# Perform the operation based on the provided command
+case "$operation" in
+    get)
+        variable_name=$1
+        quoted=false
+        shift
+
+        # Parse additional options
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                --quoted)
+                    quoted=true
+                    shift
+                    ;;
+                *)
+                    echo "Error: Unknown option '$1' for 'get' operation."
+                    exit 1
+                    ;;
+            esac
+        done
+
+        # Check if variable_name is provided
+        if [ -z "$variable_name" ]; then
+            echo "Error: Please provide a variable name for 'get' operation."
+            exit 1
+        fi
+
+        # Get the value of the environment variable based on the provided flag
+        if [ "$quoted" = true ]; then
+            quoted_value=$(get_quoted_env_value "$variable_name")
+            echo "$quoted_value"
+        else
+            value=$(get_env_value "$variable_name")
+            echo "$value"
+        fi
+        ;;
+    all)
+        secrets=false
+        non_secrets=false
+        quoted=false
+        json_output=false
+        template="%s=%s\n"
+
+        # Parse additional options
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                --secrets)
+                    secrets=true
+                    shift
+                    ;;
+                --non-secrets)
+                    non_secrets=true
+                    shift
+                    ;;
+                --quoted)
+                    quoted=true
+                    shift
+                    ;;
+                --json)
+                    json_output=true
+                    shift
+                    ;;
+                --template)
+                    template=$2
+                    shift 2
+                    ;;
+                *)
+                    echo "Error: Unknown option '$1' for 'all' operation."
+                    exit 1
+                    ;;
+            esac
+        done
+
+        if [ "$json_output" = true ]; then
+            if [ "$quoted" = true ]; then
+                echo "Error: The '--quoted' flag cannot be used with '--json' option."
+                exit 1
+            fi
+            if [ "$template" = true ]; then
+                echo "Error: The '--template' flag cannot be used with '--json' option."
+                exit 1
+            fi
+        fi
+
+        # Loop through and print environment variables based on the provided options
+        print_env_variables_custom "$secrets" "$non_secrets" "$quoted" "$json_output" "$template"
+        ;;
+    *)
+        echo "Error: Unknown operation '$operation'."
+        exit 1
+        ;;
+esac

--- a/pipeline-modules/deployment-service/aws/app-runner.yaml
+++ b/pipeline-modules/deployment-service/aws/app-runner.yaml
@@ -115,23 +115,6 @@ template: |
       commands:
         {% if job_type == 'deploy' %}
         - |
-          c=1; #Counter to check if its the last element in file
-          length=$(cat {{pipeline_env_file}} | wc -l); #Finds out the number of elements to put in json
-          echo "{" >> env.json; #start of the json file
-          cat {{pipeline_env_file}} | while IFS= read -r line; do
-            value=${line#*=}
-            name=${line%%=*}
-            if [ $c -ge $length ] #Check to add or remove trailing comma while writing JSON
-            then
-                printf '"%s":%s\n' "$name" "$value" >> env.json
-                break;
-            else
-                printf '"%s":%s,\n' "$name" "$value" >> env.json
-            fi
-          c=$((c+1)) #Incrementing the counter
-          done;
-          echo "}" >> env.json;
-
           #Delete all secrets
           secret_list=$(aws secretsmanager list-secrets --query 'SecretList[?Description && starts_with(Description, `{{service_name}}-`) == `true`].[ARN]' --output text)
           # Delete each secret in the list
@@ -140,25 +123,14 @@ template: |
             aws secretsmanager delete-secret --secret-id $secret_arn
           done
           
-          sc=1; #Rest Counter to check if its the last element in file
-          sl=$(cat {{pipeline_secret_file}} | wc -l);
-          echo "{" >> env_secrets.json; #start of the json file
-          cat {{pipeline_secret_file}} | while IFS= read -r line; do
+          secretsJSON='{}'
+          while IFS= read -r line; do
             value=${line#*=}
             name=${line%%=*}
             arn=$(aws secretsmanager create-secret --name "cp-$(date +%s)-$RANDOM" --description "{{service_name}}-$name" --secret-string $value --query 'Service.ServiceUrl' --query ARN --output text)
-            if [ $sc -ge $sl ] #Check to add or remove trailing comma while writing JSON
-            then
-                printf '"%s":"%s"\n' "$name" "$arn" >> env_secrets.json
-                break;
-            else
-                printf '"%s":"%s",\n' "$name" "$arn" >> env_secrets.json
-            fi
-          sc=$((sc+1)) #Incrementing the counter
-          done;
-          echo "}" >> env_secrets.json;
-          secretsJSON=$(cat env_secrets.json);
-          envJSON=$(cat env.json);
+            secretsJSON=$(printf "%s" $secretsJSON | jq --arg k "$name" --arg v "$arn" '. + {($k): $v}')
+          done < <(env.sh all --secrets) # non-quoted values as it is to be used in arguments;
+          envJSON=$(env.sh all --non-secrets --json);
           JSON_FMT='{
               "ImageRepository": {
                   "ImageIdentifier": "{{repository}}:{{tag}}",

--- a/pipeline-modules/deployment-service/gcp/cloud-run.yaml
+++ b/pipeline-modules/deployment-service/gcp/cloud-run.yaml
@@ -103,11 +103,13 @@ template: |
     args:
     - '-c'
     - |
-      cat {{ pipeline_secret_file }} | while IFS= read -r line; do
+      export PATH={{common_scripts_path}}:{{workspace}}/bin:$$PATH
+      env.sh all --secrets | while IFS= read -r line; do
+        # non-quoted values as it is to be used in arguments
         value=${line#*=}
         name=${line%%=*}
         gcloud secrets delete {{application_name}}-$name --quiet || true
-        printf $value | gcloud secrets create {{application_name}}-$name --data-file=- --replication-policy=user-managed --locations={{region}}
+        printf "%s" "$value" | gcloud secrets create {{application_name}}-$name --data-file=- --replication-policy=user-managed --locations={{region}}
       done;
   - id: 'Create cloud run application'
     name: 'gcr.io/cloud-builders/gcloud'
@@ -115,6 +117,7 @@ template: |
     args:
     - '-c'
     - |
+      export PATH={{common_scripts_path}}:{{workspace}}/bin:$$PATH
       client_email=$$(gcloud config list account --format "value(core.account)")
       echo "
       apiVersion: serving.knative.dev/v1
@@ -139,16 +142,13 @@ template: |
               - name: http1
                 containerPort: {{containerPort}}
               env:" >> app.yaml
-      cat {{ pipeline_env_file }} | while IFS= read -r line; do
-        value=${line#*=}
-        name=${line%%=*}
-        printf '        - name: %s\n          value: %s\n' "$name" "$value" >>  app.yaml
-      done;
-      cat {{ pipeline_secret_file }} | while IFS= read -r line; do
-        value=${line#*=}
+
+      env.sh all --non-secrets --quoted --template '        - name: %s\n          value: %s\n' >> app.yaml
+      env.sh all --secrets | while IFS= read -r line; do
         name=${line%%=*}
         printf "        - name: %s\n          valueFrom:\n            secretKeyRef:\n              key: '1'\n              name: %s\n" "$name" "{{application_name}}-$name" >>  app.yaml
       done;
+
       cat app.yaml
       gcloud run services replace app.yaml --region {{region}}
       {% if domain %}
@@ -181,8 +181,9 @@ template: |
     args:
     - '-c'
     - |
+      export PATH={{common_scripts_path}}:{{workspace}}/bin:$$PATH
       gcloud beta run services delete {{application_name}} --region {{region}} --platform managed --quiet;
-      cat {{ pipeline_secret_file }} | while IFS= read -r line; do
+      env.sh all --secrets | while IFS= read -r line; do
         value=${line#*=}
         name=${line%%=*}
         gcloud secrets delete {{application_name}}-$name --quiet || true


### PR DESCRIPTION
This change introduces a new script `env.sh` and deprecates old environment variable handling system.

fixes issues where aws app-runner and gcp cloud-run templates were adding extra `""` on sensitive env variables while sending values to secret manager.
