### PR TITLE
VAN-3785 Added the Cloud build Private Worker pool config in GCP 

### DIFF
--- a/pipeline-modules/common/gcp/pipeline-config.yaml
+++ b/pipeline-modules/common/gcp/pipeline-config.yaml
@@ -92,7 +92,7 @@ inputs:
       title: Cloud Build Worker Pool
       description: Name of Cloud Build Private Worker Pool .i.e projects/WORKERPOOL_PROJECT_ID/locations/REGION/workerPools/my-pool
       type: string
-      default: "projects/vanguard-dev-297213/locations/asia-southeast1/workerPools/worker-proxy"      
+      default: ""      
   internal:
     - pipeline_env
     - pipeline_secret_env
@@ -143,7 +143,12 @@ template: |
   - {{tag}}
   {% endfor %}
   options:
-   {% if worker_pool%}workerPool: {{ worker_pool }}{% endif %}
+  {% if worker_pool %}
+   workerPool: {{ worker_pool }}
+  {% else %}
+   {% if pipeline_machine_type %}machineType: {{ pipeline_machine_type }}{% endif %}
+   {% if pipeline_disk_size_gb %}diskSizeGb: '{{ pipeline_disk_size_gb }}'{% endif %}
+  {% endif %}
    env:
    - '__VG_EXPORTED_ENV_NAMES={% for env_key in pipeline_env %}{{env_key}} {% endfor %}'
    - '__VG_EXPORTED_SECRET_ENV_NAMES={% for env_key in pipeline_secret_env %}{{env_key}} {% endfor %}'

--- a/pipeline-modules/common/gcp/pipeline-config.yaml
+++ b/pipeline-modules/common/gcp/pipeline-config.yaml
@@ -88,6 +88,11 @@ inputs:
       title: Artifact repository
       description: Artifact repository (docker repo for containerImage or Git repo for GitCode)
       type: string
+    worker_pool:
+      title: Cloud Build Worker Pool
+      description: Name of Cloud Build Private Worker Pool .i.e projects/WORKERPOOL_PROJECT_ID/locations/REGION/workerPools/my-pool
+      type: string
+      default: "projects/vanguard-dev-297213/locations/asia-southeast1/workerPools/worker-proxy"      
   internal:
     - pipeline_env
     - pipeline_secret_env
@@ -138,8 +143,7 @@ template: |
   - {{tag}}
   {% endfor %}
   options:
-   {% if pipeline_machine_type %}machineType: {{ pipeline_machine_type }}{% endif %}
-   {% if pipeline_disk_size_gb %}diskSizeGb: '{{ pipeline_disk_size_gb }}'{% endif %}
+   {% if worker_pool%}workerPool: {{ worker_pool }}{% endif %}
    env:
    - '__VG_EXPORTED_ENV_NAMES={% for env_key in pipeline_env %}{{env_key}} {% endfor %}'
    - '__VG_EXPORTED_SECRET_ENV_NAMES={% for env_key in pipeline_secret_env %}{{env_key}} {% endfor %}'

--- a/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
@@ -101,6 +101,11 @@ inputs:
       description: Time to wait for pods to be ready before terming deployment as unsuccessful
       type: string
       default: 300s
+    cloudbuild_private_worker_pool:
+      title: Cloud Build Worker Pool
+      description: Name of Cloud Build Private Worker Pool .i.e projects/WORKERPOOL_PROJECT_ID/locations/REGION/workerPools/my-pool
+      type: string
+      default: ""        
   required:
     - cluster
     - region
@@ -284,5 +289,10 @@ template: |
     - |
       cd {{helm_chart_path}} ;
       helm list;
-      helm uninstall {{service_name}};
+      helm uninstall {{service_name}};      
   {% endif %}
+  {% if cloudbuild_private_worker_pool != "" %}    
+  options:
+    workerPool: {{ cloudbuild_private_worker_pool }}
+    diskSizeGb:  '20'
+  {% endif %}  

--- a/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
@@ -286,3 +286,4 @@ template: |
       helm list;
       helm uninstall {{service_name}};
   {% endif %}
+  

--- a/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
@@ -286,4 +286,3 @@ template: |
       helm list;
       helm uninstall {{service_name}};
   {% endif %}
-  

--- a/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
@@ -101,11 +101,6 @@ inputs:
       description: Time to wait for pods to be ready before terming deployment as unsuccessful
       type: string
       default: 300s
-    cloudbuild_private_worker_pool:
-      title: Cloud Build Worker Pool
-      description: Name of Cloud Build Private Worker Pool .i.e projects/WORKERPOOL_PROJECT_ID/locations/REGION/workerPools/my-pool
-      type: string
-      default: ""        
   required:
     - cluster
     - region
@@ -289,10 +284,5 @@ template: |
     - |
       cd {{helm_chart_path}} ;
       helm list;
-      helm uninstall {{service_name}};      
+      helm uninstall {{service_name}};
   {% endif %}
-  {% if cloudbuild_private_worker_pool != "" %}    
-  options:
-    workerPool: {{ cloudbuild_private_worker_pool }}
-    diskSizeGb:  '20'
-  {% endif %}  


### PR DESCRIPTION
We've introduced a new input, **worker_pool**, to the GCP pipeline configuration. This allows us to specify the worker pool parameter. When we utilize a private worker pool, it should follow this syntax:

It's important to note that when the workerPool option is used, the machineType and diskSizeGb parameters will be automatically unset if no value is passed for the worker_pool parameter.
  
 We unset machineType & diskSizeGb because it not required to pass with  workerPool.
  {% if worker_pool %}
   workerPool: {{ worker_pool }}
  {% else %}. 
   {% if pipeline_machine_type %}machineType: {{ pipeline_machine_type }}{% endif %}
   {% if pipeline_disk_size_gb %}diskSizeGb: '{{ pipeline_disk_size_gb }}'{% endif %}
  {% endif %}
  
  **Note** : I have tested with feature & it working fine

If anyone want to set the  worker_pool input using Codepipes cli can set: 
`#update deployment worker pool set gcp :`
`codepipes deployment update  50852751-4954-44d6-bc0c-9de2aaee90c7   --pipeline-config worker_pool=projects/vanguard-dev-297213/locations/asia-southeast1/workerPools/worker-proxy`

`codepipes deployment get  50852751-4954-44d6-bc0c-9de2aaee90c7  -D`
  
  