### PR TITLE
VAN-2358 Rename release template

### DIFF
--- a/build-pipeline/int-prod-release.yml
+++ b/build-pipeline/int-prod-release.yml
@@ -21,7 +21,7 @@ variables:
   - group: CodePipes-Int-Prod-DB
 
 steps:
-  - template: templates/ci-cd-modules-release.yml@templates
+  - template: templates/run-db-update.yml@templates
     parameters:
       gcpSACreds: $(GCP_SA_CREDS)
       DBInstanceConnectionName: $(DB_INSTANCE_CONNECTION_NAME)

--- a/build-pipeline/prod-release.yml
+++ b/build-pipeline/prod-release.yml
@@ -21,7 +21,7 @@ variables:
   - group: CodePipes-Production-DB
 
 steps:
-  - template: templates/ci-cd-modules-release.yml@templates
+  - template: templates/run-db-update.yml@templates
     parameters:
       gcpSACreds: $(GCP_SA_CREDS)
       DBInstanceConnectionName: $(DB_INSTANCE_CONNECTION_NAME)

--- a/build-pipeline/staging-release.yml
+++ b/build-pipeline/staging-release.yml
@@ -27,7 +27,7 @@ stages:
       - job: Release_Staging
         displayName: Release to GCP Staging
         steps:
-          - template: templates/ci-cd-modules-release.yml@templates
+          - template: templates/run-db-update.yml@templates
             parameters:
               gcpSACreds: $(GCP_SA_CREDS)
               DBInstanceConnectionName: $(DB_INSTANCE_CONNECTION_NAME)


### PR DESCRIPTION
The "ci-cd-module-release" template is now called "run-db-update".
