### PR TITLE
VAN-4153 Updated Image to latest for faster build and deploy

### DIFF
--- a/pipeline-modules/common/aws/pipeline-config.yaml
+++ b/pipeline-modules/common/aws/pipeline-config.yaml
@@ -129,7 +129,7 @@ template: |
       value: "{{ env_value }}"
       type: "SECRETS_MANAGER"
     {% endfor %}
-    image: "aws/codebuild/standard:4.0"
+    image: "aws/codebuild/standard:7.0"
     imagepullcredentialstype: "CODEBUILD"
     privilegedmode: {{ privileged_mode }}
     registrycredential: null


### PR DESCRIPTION
* Updated the image to latest ECS Image "aws/codebuild/standard:7.0" so that cached image can be used which results in faster build.
* The image currently in use "aws/codebuild/standard:4.0" has been deprecated by AWS.
* Have tested the build, ECS Deploy with this already and those work without any issue. 