### PR TITLE
VN-4031 Set minimum values for pipeline configuration

### DIFF
--- a/pipeline-modules/common/aws/pipeline-config.yaml
+++ b/pipeline-modules/common/aws/pipeline-config.yaml
@@ -40,6 +40,7 @@ inputs:
       description: Amount of time in minutes the pipeline will be allowed to run.
       type: integer
       default: 60
+      minimum: 1
     pipeline_secret_env:
       title: Global Secret Environment
       description: Mapping of globally available secret variable id.

--- a/pipeline-modules/common/gcp/pipeline-config.yaml
+++ b/pipeline-modules/common/gcp/pipeline-config.yaml
@@ -22,6 +22,7 @@ inputs:
       title: Disk Size [GB]
       description: Amount of disk space in GB allocated for the pipeline.
       type: integer
+      minimum: 1
       default: 300
       maximum: 1000
     pipeline_env:
@@ -60,13 +61,14 @@ inputs:
       title: Timeout [s]
       description: Amount of time in seconds the pipeline will be allowed to run.
       type: integer
-      minimum: 0
+      minimum: 1
       maximum: 86400 # 24*60*60
       default: 4000
     pipeline_queue_timeout_sec:
       title: Queue Timeout [s]
       description: Amount of time in seconds the pipeline will be allowed to be queued waiting to run.
       type: integer
+      minimum: 1
       default: 7200
     pipeline_module_git:
       title: Pipeline module git repo url
@@ -92,7 +94,7 @@ inputs:
       title: Cloud Build Worker Pool
       description: Name of Cloud Build Private Worker Pool .i.e projects/WORKERPOOL_PROJECT_ID/locations/REGION/workerPools/my-pool
       type: string
-      default: ""      
+      default: ""
   internal:
     - pipeline_env
     - pipeline_secret_env

--- a/pipeline-modules/infra-service/aws/pipeline-config.yaml
+++ b/pipeline-modules/infra-service/aws/pipeline-config.yaml
@@ -40,11 +40,13 @@ inputs:
       description: Amount of time in minutes the pipeline will be allowed to run.
       type: integer
       default: 480
+      minimum: 1
     pipeline_queue_timeout_min:
       title: Queue Timeout [min]
       description: Amount of time in minutes the pipeline will be allowed to be queued waiting to run.
       type: integer
       default: 480
+      minimum: 1
     pipeline_secret_env:
       title: Global Secret Environment
       description: Mapping of globally available secret variable id.

--- a/pipeline-modules/infra-service/gcp/pipeline-config.yaml
+++ b/pipeline-modules/infra-service/gcp/pipeline-config.yaml
@@ -23,6 +23,7 @@ inputs:
       type: integer
       default: 300
       maximum: 1000
+      minimum: 1
     pipeline_env:
       title: Global Environment
       description: Mapping of globally available variables to values.
@@ -61,11 +62,13 @@ inputs:
       type: integer
       default: 4000
       maximum: 86400 # 24*60*60
+      minimum: 1
     pipeline_queue_timeout_sec:
       title: Queue Timeout [s]
       description: Amount of time in seconds the pipeline will be allowed to be queued waiting to run.
       type: integer
       default: 7200
+      minimum: 1
   internal:
     - pipeline_env
     - pipeline_secret_env


### PR DESCRIPTION
This prevents the users from accidently setting an invalid value in the basic integer metrics.