### PR TITLE
VAN-4291 Remove Pool_name from  module level In Azure

### DIFF
--- a/pipeline-modules/app-service/azure/bash.yaml
+++ b/pipeline-modules/app-service/azure/bash.yaml
@@ -17,11 +17,7 @@ inputs:
       title: Bash script
       description: This is a bash script
       type: string
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""
+
     working_dir:
       title: Working directory
       description: The current working directory to execute the bash script from

--- a/pipeline-modules/app-service/azure/best-practice-appsec.yaml
+++ b/pipeline-modules/app-service/azure/best-practice-appsec.yaml
@@ -24,10 +24,6 @@ inputs:
       description: Code Pipes application name
       type: string
       default: ""
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
     fortify_application_id:
       title: Fortify application id
       description: Fortify application identifier
@@ -51,8 +47,6 @@ inputs:
     - git_local_path
     - working_dir
     - applicationName
-  required:
-    - pool_name
 template: |
   {% set scancentral = '/home/azureuser/client/bin/scancentral' %}
   {% set pipeline_env_file = workspace|add:'/.env' %}

--- a/pipeline-modules/app-service/azure/docker-build-n-push.yaml
+++ b/pipeline-modules/app-service/azure/docker-build-n-push.yaml
@@ -35,11 +35,7 @@ inputs:
       description: The current working directory to execute command
       type: string
       default: repo
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""
+
     use_github_tag:
       title: Use github tag
       description: true value will push the image reference with git commit sha tag as well

--- a/pipeline-modules/app-service/azure/dotnet-build.yaml
+++ b/pipeline-modules/app-service/azure/dotnet-build.yaml
@@ -13,11 +13,7 @@ author: CloudCover
 meta: {}
 inputs:
   properties:
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""
+
     working_dir:
       title: Code Directory Path
       description: Directory Path where the code is located.

--- a/pipeline-modules/app-service/azure/fortify-selfhosted.yaml
+++ b/pipeline-modules/app-service/azure/fortify-selfhosted.yaml
@@ -64,11 +64,7 @@ inputs:
       description:  Upper limit to number of warning level vulnarabilities allowed  
       type: string
       default:
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""
+
   internal:
     - working_dir
   required:

--- a/pipeline-modules/app-service/azure/fortify.yaml
+++ b/pipeline-modules/app-service/azure/fortify.yaml
@@ -17,11 +17,7 @@ env:
   - CPI__FORTIFY_TOKEN
 inputs:
   properties:
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""
+
     fortify_application_id:
       title: Fortify Application ID
       description: If not provided Code Pipes application name will be used

--- a/pipeline-modules/app-service/azure/go-build.yaml
+++ b/pipeline-modules/app-service/azure/go-build.yaml
@@ -31,11 +31,6 @@ inputs:
       description: The version of Golang to use
       type: string
       default: "1.15.15"
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by providing agent pool name.
-      type: string
-      default: ""
   internal:
     - working_dir
 template: |

--- a/pipeline-modules/app-service/azure/go-scan.yaml
+++ b/pipeline-modules/app-service/azure/go-scan.yaml
@@ -43,11 +43,7 @@ inputs:
       description: The current working directory to execute command
       type: string
       default: repo
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""
+
   internal:
     - working_dir
 template: |

--- a/pipeline-modules/app-service/azure/java-build.yaml
+++ b/pipeline-modules/app-service/azure/java-build.yaml
@@ -19,11 +19,7 @@ inputs:
       description: The current working directory to execute command
       type: string
       default: repo
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""
+
   internal:
   - working_dir
 template: |

--- a/pipeline-modules/app-service/azure/java-unit-test.yaml
+++ b/pipeline-modules/app-service/azure/java-unit-test.yaml
@@ -25,11 +25,7 @@ inputs:
       default: []
       items:
         type: string
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""
+
   internal:
     - working_dir
 template: |

--- a/pipeline-modules/app-service/azure/publish-artifact.yaml
+++ b/pipeline-modules/app-service/azure/publish-artifact.yaml
@@ -17,11 +17,7 @@ inputs:
       title: SHA Git commit tag
       description: Resolved Commit hash for Input git artifact
       type: string  
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""
+
     applicationName:
       title: Application name
       description: Code Pipes application name

--- a/pipeline-modules/app-service/azure/sonarcloud.yaml
+++ b/pipeline-modules/app-service/azure/sonarcloud.yaml
@@ -45,11 +45,7 @@ inputs:
       description: Unit test coverage file to be analyzed by SonarCloud
       type: string
       default: "coverage.out"
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""
+
   required:
     - sonar_cloud_service_connection
     - sonar_cloud_org

--- a/pipeline-modules/app-service/azure/sonarqube.yaml
+++ b/pipeline-modules/app-service/azure/sonarqube.yaml
@@ -34,11 +34,7 @@ inputs:
       description: If not provided, Code Pipes application name will be used
       type: string
       default: ""
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""
+
   internal:
     - git_local_path
     - working_dir

--- a/pipeline-modules/app-service/azure/sonatype-nexus.yaml
+++ b/pipeline-modules/app-service/azure/sonatype-nexus.yaml
@@ -21,11 +21,7 @@ inputs:
       description: NexusIQ application id
       type: string
       default: ""
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""
+
     applicationName:
       title: Application name
       description: Code Pipes application name

--- a/pipeline-modules/deployment-service/azure/aks-cert-manager.yaml
+++ b/pipeline-modules/deployment-service/azure/aks-cert-manager.yaml
@@ -117,11 +117,7 @@ inputs:
       description: Name of the Azure DNS Hosted Zone for CertManager for which certificate is required
       type: string
       default: ""
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""      
+      
   required:
     - cluster
     - resourceGroup

--- a/pipeline-modules/deployment-service/azure/avtok8s-kv-driver.yaml
+++ b/pipeline-modules/deployment-service/azure/avtok8s-kv-driver.yaml
@@ -38,11 +38,7 @@ inputs:
       description: This is to deploy or undeploy application
       type: string
       default: akv2k8s
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""      
+      
   required:
     - cluster
     - resourceGroup

--- a/pipeline-modules/deployment-service/azure/azure-functions.yaml
+++ b/pipeline-modules/deployment-service/azure/azure-functions.yaml
@@ -37,11 +37,7 @@ inputs:
       description: Function App Name, to link this variable to a terraform output use this syntax ${terraform.func_name.value} where func_name is output variable key.
       type: string
       tfOutputRegex: "^func"
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""
+
     job_type:
       title: Job Type
       description: This is to deploy or undeploy application

--- a/pipeline-modules/deployment-service/azure/azure-web-app.yaml
+++ b/pipeline-modules/deployment-service/azure/azure-web-app.yaml
@@ -35,11 +35,7 @@ inputs:
       title: Web App Name
       description: Web App Name, to link this variable to a terraform output use this syntax ${terraform.webapp_name.value} where webapp_name is output variable key.
       type: string
-    pool_name:
-      title: Pool Name
-      description: Use selfhosted agent by proving agent pool name.
-      type: string
-      default: ""
+
     job_type:
       title: Job Type
       description: This is to deploy or undeploy application

--- a/pipeline-modules/deployment-service/azure/basic-aks-module.yaml
+++ b/pipeline-modules/deployment-service/azure/basic-aks-module.yaml
@@ -114,12 +114,7 @@ inputs:
       title: Working Directory
       description: Working Directory where the code is to be run
       type: string
-      default: $(Build.SourcesDirectory)
-    pool_name:
-      title: Pool Name
-      description: Use  Azure selfhosted agent by proving agent pool name.
-      type: string
-      default: ""      
+      default: $(Build.SourcesDirectory) 
   required:
     - cluster
     - resourceGroup

--- a/pipeline-modules/deployment-service/azure/istio-aks-module.yaml
+++ b/pipeline-modules/deployment-service/azure/istio-aks-module.yaml
@@ -267,11 +267,7 @@ inputs:
       description: This will deploy acme certificate issuer with letsencrypt as signing authority
       type: boolean
       default: false
-    pool_name:
-      title: Pool Name
-      description: Use  Azure selfhosted agent by proving agent pool name.
-      type: string
-      default: ""      
+    
   required:
     - cluster
     - resourceGroup

--- a/pipeline-modules/deployment-service/azure/key-vault-driver.yaml
+++ b/pipeline-modules/deployment-service/azure/key-vault-driver.yaml
@@ -41,12 +41,7 @@ inputs:
     publicIP:
       title: Public IP
       description: This is Public IP to be alloted to the Load Balancer
-      type: string
-    pool_name:
-      title: Pool Name
-      description: Use  Azure selfhosted agent by proving agent pool name.
-      type: string
-      default: ""      
+      type: string   
 
   required:
     - cluster


### PR DESCRIPTION
Since the pool_name is already set in the pipeline config module, there's no need to include it at every module level, so we will remove it.