### PR TITLE
VAN-4366 Enhance the pipeline_compute_type input to accept an enum AWS pipelien conifg

### DIFF
--- a/pipeline-modules/common/aws/pipeline-config.yaml
+++ b/pipeline-modules/common/aws/pipeline-config.yaml
@@ -17,9 +17,14 @@ inputs:
   properties:
     pipeline_compute_type:
       title: Compute Type
-      description: Specifies the compute resources used by this build environment.
+      description: Specifies the compute resources used by this build environment. URL- "https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html"
       type: string
       default: BUILD_GENERAL1_SMALL
+      enum:
+        - BUILD_GENERAL1_SMALL
+        - BUILD_GENERAL1_MEDIUM        
+        - BUILD_GENERAL1_LARGE
+        - BUILD_GENERAL1_2XLARGE
     pipeline_env:
       title: Global Environment
       description: Mapping of globally available variables to values.

--- a/pipeline-modules/infra-service/aws/pipeline-config.yaml
+++ b/pipeline-modules/infra-service/aws/pipeline-config.yaml
@@ -17,9 +17,14 @@ inputs:
   properties:
     pipeline_compute_type:
       title: Compute Type
-      description: Specifies the compute resources used by this build environment.
+      description: Specifies the compute resources used by this build environment. URL- "https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html"
       type: string
       default: BUILD_GENERAL1_MEDIUM
+      enum:
+        - BUILD_GENERAL1_SMALL
+        - BUILD_GENERAL1_MEDIUM        
+        - BUILD_GENERAL1_LARGE
+        - BUILD_GENERAL1_2XLARGE
     pipeline_env:
       title: Global Environment
       description: Mapping of globally available variables to values.


### PR DESCRIPTION
We are enhancing the "pipeline_compute_type" input to accept an enumeration (enum) where you can specify a list of available compute systems for running code builds on AWS.




