### PR TITLE
VAN-4315 Add List of Runtime Docker image for Codebuild pipeline

### DIFF
--- a/pipeline-modules/common/aws/pipeline-config.yaml
+++ b/pipeline-modules/common/aws/pipeline-config.yaml
@@ -25,6 +25,22 @@ inputs:
         - BUILD_GENERAL1_MEDIUM        
         - BUILD_GENERAL1_LARGE
         - BUILD_GENERAL1_2XLARGE
+    pipeline_image:
+      title: CodeBuild Image Type
+      description: AWS CodeBuild supports the following Docker images that are available in the CodeBuild. URL- "https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html"
+      type: string
+      default: "aws/codebuild/standard:7.0"
+      enum:
+        - aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        - aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        - aws/codebuild/amazonlinux2-x86_64-standard:corretto8
+        - aws/codebuild/amazonlinux2-x86_64-standard:corretto11
+        - aws/codebuild/amazonlinux2-aarch64-standard:3.0
+        - aws/codebuild/standard:5.0
+        - aws/codebuild/standard:6.0
+        - aws/codebuild/standard:7.0
+        - aws/codebuild/windows-base:2019-1.0
+        - aws/codebuild/windows-base:2019-2.0
     pipeline_env:
       title: Global Environment
       description: Mapping of globally available variables to values.
@@ -149,7 +165,7 @@ template: |
       value: "{{ env_value }}"
       type: "SECRETS_MANAGER"
     {% endfor %}
-    image: "aws/codebuild/standard:7.0"
+    image : {{ pipeline_image }}
     imagepullcredentialstype: "CODEBUILD"
     privilegedmode: {{ privileged_mode }}
     registrycredential: null

--- a/pipeline-modules/common/aws/pipeline-config.yaml
+++ b/pipeline-modules/common/aws/pipeline-config.yaml
@@ -122,7 +122,6 @@ inputs:
       title: Pipeline module git repo revision
       description: git revision for cloning the pipeline module repo.
       type: string
-
   internal:
     - pipeline_logs_bucket
     - pipeline_env

--- a/pipeline-modules/common/aws/pipeline-config.yaml
+++ b/pipeline-modules/common/aws/pipeline-config.yaml
@@ -130,7 +130,7 @@ inputs:
     - pipeline_module_git
     - pipeline_module_git_rev
     - pipeline_job_id
-
+    
 template: |
   {% set workspace = '$CODEBUILD_SRC_DIR' %}   {# has to be a persistent volume #}
   {% set pipeline_modules_path = workspace|add:'/pipeline_modules' %}

--- a/pipeline-modules/infra-service/aws/pipeline-config.yaml
+++ b/pipeline-modules/infra-service/aws/pipeline-config.yaml
@@ -25,6 +25,22 @@ inputs:
         - BUILD_GENERAL1_MEDIUM        
         - BUILD_GENERAL1_LARGE
         - BUILD_GENERAL1_2XLARGE
+    pipeline_image:
+      title: CodeBuild Image Type
+      description: AWS CodeBuild supports the following Docker images that are available in the CodeBuild. URL- "https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html"
+      type: string
+      default: "aws/codebuild/standard:5.0"
+      enum:
+        - aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        - aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        - aws/codebuild/amazonlinux2-x86_64-standard:corretto8
+        - aws/codebuild/amazonlinux2-x86_64-standard:corretto11
+        - aws/codebuild/amazonlinux2-aarch64-standard:3.0
+        - aws/codebuild/standard:5.0
+        - aws/codebuild/standard:6.0
+        - aws/codebuild/standard:7.0
+        - aws/codebuild/windows-base:2019-1.0
+        - aws/codebuild/windows-base:2019-2.0        
     pipeline_env:
       title: Global Environment
       description: Mapping of globally available variables to values.
@@ -136,7 +152,7 @@ template: |
       value: "{{ env_value }}"
       type: "SECRETS_MANAGER"
     {% endfor %}
-    image: "aws/codebuild/standard:5.0"
+    image: {{ pipeline_image }}
     imagepullcredentialstype: "CODEBUILD"
     privilegedmode: {{ privileged_mode }}
     registrycredential: null


### PR DESCRIPTION
As we know we have hard-coded the image docker image where the code build will run on the AWS Pipeline config. 
So we allow use to choose any image where you codebuild pipline will run .
We will enable users to select their CodeBuild image type from a list of Docker images offered by AWS. You can refer to the available options in the following documentation: [[AWS CodeBuild Build Environment Reference](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html)]