### PR TITLE
VAN-4358 Update timeoutInMinutes  & queuedTimeoutInMinutes min & max time 

### DIFF
--- a/pipeline-modules/common/aws/pipeline-config.yaml
+++ b/pipeline-modules/common/aws/pipeline-config.yaml
@@ -61,7 +61,15 @@ inputs:
       description: Amount of time in minutes the pipeline will be allowed to run.
       type: integer
       default: 60
-      minimum: 1
+      minimum: 5
+      maximum: 480
+    pipeline_queue_timeout_min:
+      title: Queue Timeout [min]
+      description: Amount of time in minutes the pipeline will be allowed to be queued waiting to run.
+      type: integer
+      default: 60
+      minimum: 5
+      maximum: 480        
     pipeline_secret_env:
       title: Global Secret Environment
       description: Mapping of globally available secret variable id.

--- a/pipeline-modules/infra-service/aws/pipeline-config.yaml
+++ b/pipeline-modules/infra-service/aws/pipeline-config.yaml
@@ -61,13 +61,15 @@ inputs:
       description: Amount of time in minutes the pipeline will be allowed to run.
       type: integer
       default: 480
-      minimum: 1
+      minimum: 5
+      maximum: 480 
     pipeline_queue_timeout_min:
       title: Queue Timeout [min]
       description: Amount of time in minutes the pipeline will be allowed to be queued waiting to run.
       type: integer
-      default: 480
-      minimum: 1
+      default: 60
+      minimum: 5
+      maximum: 480      
     pipeline_secret_env:
       title: Global Secret Environment
       description: Mapping of globally available secret variable id.


### PR DESCRIPTION
Updated timeoutInMinutes  & queuedTimeoutInMinutes min & max time  as suggested by[ aws doc](https://docs.aws.amazon.com/codebuild/latest/userguide/create-project-cli.html) in AWS infra pipeline config & Aws App pipeline config.

**timeoutInMinutes**
Optional. The number of minutes, is between 5 to 480 (8 hours), after which CodeBuild stops the build if it is not complete. If not specified, the default of 60 is used. To determine if and when CodeBuild stopped a build due to a timeout, run the batch-get-builds command. To determine if the build has stopped, look in the output for a buildStatus value of FAILED. To determine when the build timed out, look in the output for the endTime value associated with a phaseStatus value of TIMED_OUT.

**queuedTimeoutInMinutes**
Optional. The number of minutes, between 5 to 480 (8 hours), after which CodeBuild stops the build if it is is still queued. If not specified, the default of 60 is used.

