### PR TITLE
VAN-4322 Improve Status Reporting for Helm Rollback and Failed Deployments

### DIFF
--- a/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
+++ b/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
@@ -133,6 +133,11 @@ inputs:
       description: Time to wait for pods to be ready before terming deployment as unsuccessful
       type: string
       default: 300s
+    rollback_enable:
+      title: Enable Automatic Rollback
+      description: Enabling this option will automatically trigger a rollback of the Helm release in case of deployment failure during the previous deployment.
+      type: boolean
+      default: true
   required:
     - cluster
     - region
@@ -297,7 +302,34 @@ template: |
           name=${line%%=*}
           printf '  %s: %s\n' $name $value >> values.yaml
           done;
-        - helm upgrade --install -f values.yaml {{service_name}} . --atomic --timeout {{deployment_timeout}}
+        - |
+          helm upgrade --install -f values.yaml {{service_name}} . --wait --timeout {{deployment_timeout}}
+          {% if rollback_enable %}
+            #Get Status code
+            helm_upgrade_exit_status=$?
+            echo 'Helm release failed with EXIT_CODE: '$helm_upgrade_exit_status''
+            # Check the Helm upgrade/install status
+            if [ $helm_upgrade_exit_status -eq 0 ]; then
+              echo "Helm upgrade/install successful...."
+            else
+              #If helm release failed than rollback
+              echo "Helm upgrade/install failed. Rolling back pervious version..."
+              
+              # Perform the Helm rollback
+              helm  rollback {{service_name}}  0 --wait --timeout {{deployment_timeout}}
+              if [ $? -eq 0 ]; then
+                echo "Helm Rollback completed..."
+                echo "Action Required: Check your deployment  on k8s cluster why it Rollbacked"
+                kubectl rollout restart deployment {{fmt_app_name}}-deployment -n {{fmt_app_name}}
+                kubectl rollout status deployment {{fmt_app_name}}-deployment   -n {{fmt_app_name}}          
+                # Exit with a non-zero status code to indicate pipeline failure
+                exit 1
+              else
+                echo "Helm Rollback also failed ..."
+                exit 1
+              fi
+            fi
+          {% endif %}
         - kubectl rollout restart deployment {{fmt_app_name}}-deployment -n {{fmt_app_name}}
         - kubectl rollout status deployment {{fmt_app_name}}-deployment   -n {{fmt_app_name}}
 

--- a/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
+++ b/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
@@ -307,7 +307,7 @@ template: |
           {% if rollback_enable %}
             #Get Status code
             helm_upgrade_exit_status=$?
-            echo 'Helm release failed with EXIT_CODE: '$helm_upgrade_exit_status''
+            echo 'Helm release status of EXIT_CODE: '$helm_upgrade_exit_status''
             # Check the Helm upgrade/install status
             if [ $helm_upgrade_exit_status -eq 0 ]; then
               echo "Helm upgrade/install successful...."

--- a/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
+++ b/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
@@ -312,7 +312,7 @@ template: |
             if [ $helm_upgrade_exit_status -eq 0 ]; then
               echo "Helm upgrade/install successful...."
             else
-              #If helm release failed than rollback
+              # Helm upgrade/install failed
               echo "Helm upgrade/install failed. Rolling back pervious version..."
               
               # Perform the Helm rollback

--- a/pipeline-modules/deployment-service/aws/istio-eks-module.yaml
+++ b/pipeline-modules/deployment-service/aws/istio-eks-module.yaml
@@ -15,6 +15,11 @@ meta:
 
 inputs:
   properties:
+    rollback_enable:
+      title: Enable Automatic Rollback
+      description: Enabling this option will automatically trigger a rollback of the Helm release in case of deployment failure during the previous deployment.
+      type: boolean
+      default: true
     istioInjection:
       title: Istio Injection Enabled
       description: Enable Istio Injection in namespace
@@ -440,7 +445,34 @@ template: |
           printf '  %s: %s\n' $name $value >> values.yaml
           done;
 
-        - helm upgrade --install -f values.yaml {{service_name}} . #--atomic --timeout {{deployment_timeout}}
+        - |
+          helm upgrade --install -f values.yaml {{service_name}} . --wait --timeout {{deployment_timeout}}
+          {% if rollback_enable %}
+            #Get Status code
+            helm_upgrade_exit_status=$?
+            echo 'Helm release failed with EXIT_CODE: '$helm_upgrade_exit_status''
+            # Check the Helm upgrade/install status
+            if [ $helm_upgrade_exit_status -eq 0 ]; then
+              echo "Helm upgrade/install successful...."
+            else
+              #If helm release failed than rollback
+              echo "Helm upgrade/install failed. Rolling back pervious version..."
+              
+              # Perform the Helm rollback
+              helm  rollback {{service_name}}  0 --wait --timeout {{deployment_timeout}}
+              if [ $? -eq 0 ]; then
+                echo "Helm Rollback completed..."
+                echo "Action Required: Check your deployment  on k8s cluster why it Rollbacked"
+                kubectl rollout restart deployment {{fmt_app_name}}-deployment -n {{fmt_app_name}}
+                kubectl rollout status deployment {{fmt_app_name}}-deployment   -n {{fmt_app_name}}          
+                # Exit with a non-zero status code to indicate pipeline failure
+                exit 1
+              else
+                echo "Helm Rollback also failed ..."
+                exit 1
+              fi
+            fi
+          {% endif %}
         - kubectl rollout restart deployment {{fmt_app_name}}-deployment -n {{fmt_app_name}}
         - kubectl rollout status deployment {{fmt_app_name}}-deployment   -n {{fmt_app_name}}
 

--- a/pipeline-modules/deployment-service/aws/istio-eks-module.yaml
+++ b/pipeline-modules/deployment-service/aws/istio-eks-module.yaml
@@ -450,7 +450,7 @@ template: |
           {% if rollback_enable %}
             #Get Status code
             helm_upgrade_exit_status=$?
-            echo 'Helm release failed with EXIT_CODE: '$helm_upgrade_exit_status''
+            echo 'Helm release status of EXIT_CODE: '$helm_upgrade_exit_status''
             # Check the Helm upgrade/install status
             if [ $helm_upgrade_exit_status -eq 0 ]; then
               echo "Helm upgrade/install successful...."

--- a/pipeline-modules/deployment-service/aws/istio-eks-module.yaml
+++ b/pipeline-modules/deployment-service/aws/istio-eks-module.yaml
@@ -455,7 +455,7 @@ template: |
             if [ $helm_upgrade_exit_status -eq 0 ]; then
               echo "Helm upgrade/install successful...."
             else
-              #If helm release failed than rollback
+              # Helm upgrade/install failed
               echo "Helm upgrade/install failed. Rolling back pervious version..."
               
               # Perform the Helm rollback

--- a/pipeline-modules/deployment-service/azure/basic-aks-module.yaml
+++ b/pipeline-modules/deployment-service/azure/basic-aks-module.yaml
@@ -13,6 +13,11 @@ meta:
     - ContainerImage
 inputs:
   properties:
+    rollback_enable:
+      title: Enable Automatic Rollback
+      description: Enabling this option will automatically trigger a rollback of the Helm release in case of deployment failure during the previous deployment.
+      type: boolean
+      default: true   
     ports:
       title: Ports
       description: Port used in services
@@ -244,7 +249,33 @@ template: |
       workingDirectory: {{ workingDir }}
     - script: |
             cd {{helm_chart_path}} ;
-            helm upgrade --install -f values.yaml {{service_name}} . --atomic --timeout {{deployment_timeout}}
+            helm upgrade --install -f values.yaml {{service_name}} . --wait --timeout {{deployment_timeout}}
+          {% if rollback_enable %}
+            #Get Status code
+            helm_upgrade_exit_status=$?
+            echo 'Helm release failed with EXIT_CODE: '$helm_upgrade_exit_status''
+            # Check the Helm upgrade/install status
+            if [ $helm_upgrade_exit_status -eq 0 ]; then
+              echo "Helm upgrade/install successful...."
+            else
+              #If helm release failed than rollback
+              echo "Helm upgrade/install failed. Rolling back pervious version..."
+              
+              # Perform the Helm rollback
+              helm  rollback {{service_name}}  0 --wait --timeout {{deployment_timeout}}
+              if [ $? -eq 0 ]; then
+                echo "Helm Rollback completed..."
+                echo "Action Required: Check your deployment  on k8s cluster why it Rollbacked"
+                kubectl rollout restart deployment {{fmt_app_name}}-deployment -n {{fmt_app_name}}
+                kubectl rollout status deployment {{fmt_app_name}}-deployment   -n {{fmt_app_name}}          
+                # Exit with a non-zero status code to indicate pipeline failure
+                exit 1
+              else
+                echo "Helm Rollback also failed ..."
+                exit 1
+              fi
+            fi
+          {% endif %}
             kubectl rollout restart deployment {{fmt_app_name}}-deployment -n {{fmt_app_name}}
             kubectl rollout status deployment {{fmt_app_name}}-deployment   -n {{fmt_app_name}}
 

--- a/pipeline-modules/deployment-service/azure/basic-aks-module.yaml
+++ b/pipeline-modules/deployment-service/azure/basic-aks-module.yaml
@@ -253,7 +253,7 @@ template: |
           {% if rollback_enable %}
             #Get Status code
             helm_upgrade_exit_status=$?
-            echo 'Helm release failed with EXIT_CODE: '$helm_upgrade_exit_status''
+            echo 'Helm release status of EXIT_CODE: '$helm_upgrade_exit_status''
             # Check the Helm upgrade/install status
             if [ $helm_upgrade_exit_status -eq 0 ]; then
               echo "Helm upgrade/install successful...."

--- a/pipeline-modules/deployment-service/azure/basic-aks-module.yaml
+++ b/pipeline-modules/deployment-service/azure/basic-aks-module.yaml
@@ -258,7 +258,7 @@ template: |
             if [ $helm_upgrade_exit_status -eq 0 ]; then
               echo "Helm upgrade/install successful...."
             else
-              #If helm release failed than rollback
+              # Helm upgrade/install failed
               echo "Helm upgrade/install failed. Rolling back pervious version..."
               
               # Perform the Helm rollback

--- a/pipeline-modules/deployment-service/azure/istio-aks-module.yaml
+++ b/pipeline-modules/deployment-service/azure/istio-aks-module.yaml
@@ -15,6 +15,11 @@ meta:
 
 inputs:
   properties:
+    rollback_enable:
+      title: Enable Automatic Rollback
+      description: Enabling this option will automatically trigger a rollback of the Helm release in case of deployment failure during the previous deployment.
+      type: boolean
+      default: true  
     istioInjection:
       title: Istio Injection Enabled
       description: Enable Istio Injection in namespace
@@ -447,7 +452,34 @@ template: |
             cd {{helm_chart_path}} ;
             ls -la;
             cat values.yaml;
-            helm upgrade --install -f values.yaml {{service_name}} . #--atomic --timeout {{deployment_timeout}}
+            helm upgrade --install -f values.yaml {{service_name}} . --wait --timeout {{deployment_timeout}}
+          {% if rollback_enable %}
+            #Get Status code
+            helm_upgrade_exit_status=$?
+            echo 'Helm release failed with EXIT_CODE: '$helm_upgrade_exit_status''
+            # Check the Helm upgrade/install status
+            if [ $helm_upgrade_exit_status -eq 0 ]; then
+              echo "Helm upgrade/install successful...."
+            else
+              #If helm release failed than rollback
+              echo "Helm upgrade/install failed. Rolling back pervious version..."
+              
+              # Perform the Helm rollback
+              helm  rollback {{service_name}}  0 --wait --timeout {{deployment_timeout}}
+              if [ $? -eq 0 ]; then
+                echo "Helm Rollback completed..."
+                echo "Action Required: Check your deployment  on k8s cluster why it Rollbacked"
+                kubectl rollout restart deployment {{fmt_app_name}}-deployment -n {{fmt_app_name}}
+                kubectl rollout status deployment {{fmt_app_name}}-deployment   -n {{fmt_app_name}}          
+                # Exit with a non-zero status code to indicate pipeline failure
+                exit 1
+              else
+                echo "Helm Rollback also failed ..."
+                exit 1
+              fi
+            fi
+          {% endif %}
+            #Restarting the deployment to pick the recent change to running pod
             kubectl rollout restart deployment {{fmt_app_name}}-deployment -n {{fmt_app_name}}
             kubectl rollout status deployment {{fmt_app_name}}-deployment   -n {{fmt_app_name}}
 

--- a/pipeline-modules/deployment-service/azure/istio-aks-module.yaml
+++ b/pipeline-modules/deployment-service/azure/istio-aks-module.yaml
@@ -461,7 +461,7 @@ template: |
             if [ $helm_upgrade_exit_status -eq 0 ]; then
               echo "Helm upgrade/install successful...."
             else
-              #If helm release failed than rollback
+              # Helm upgrade/install failed
               echo "Helm upgrade/install failed. Rolling back pervious version..."
               
               # Perform the Helm rollback

--- a/pipeline-modules/deployment-service/azure/istio-aks-module.yaml
+++ b/pipeline-modules/deployment-service/azure/istio-aks-module.yaml
@@ -456,7 +456,7 @@ template: |
           {% if rollback_enable %}
             #Get Status code
             helm_upgrade_exit_status=$?
-            echo 'Helm release failed with EXIT_CODE: '$helm_upgrade_exit_status''
+            echo 'Helm release status of EXIT_CODE: '$helm_upgrade_exit_status''
             # Check the Helm upgrade/install status
             if [ $helm_upgrade_exit_status -eq 0 ]; then
               echo "Helm upgrade/install successful...."

--- a/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
@@ -16,6 +16,11 @@ meta:
     - google_container_cluster
 inputs:
   properties:
+    rollback_enable:
+      title: Enable Automatic Rollback
+      description: Enabling this option will automatically trigger a rollback of the Helm release in case of deployment failure during the previous deployment.
+      type: boolean
+      default: true
     app_env:
       title: Application Environment
       description: Application Related Envs
@@ -252,7 +257,33 @@ template: |
     - '-c'
     - |
       cd {{helm_chart_path}} ;
-      helm upgrade --install -f values.yaml {{service_name}} . --atomic --timeout {{deployment_timeout}}
+      helm upgrade --install -f values.yaml {{service_name}} . --wait --timeout {{deployment_timeout}}
+    {% if rollback_enable %}
+      #Get Status code
+      helm_upgrade_exit_status=$?
+      echo 'Helm release failed with EXIT_CODE: '$helm_upgrade_exit_status''
+      # Check the Helm upgrade/install status
+      if [ $helm_upgrade_exit_status -eq 0 ]; then
+        echo "Helm upgrade/install successful...."
+      else
+        #If helm release failed than rollback
+        echo "Helm upgrade/install failed. Rolling back pervious version..."
+        
+        # Perform the Helm rollback
+        helm  rollback {{service_name}}  0 --wait --timeout {{deployment_timeout}}
+        if [ $? -eq 0 ]; then
+          echo "Helm Rollback completed..."
+          echo "Action Required: Check your deployment  on k8s cluster why it Rollbacked"
+          kubectl rollout restart deployment {{fmt_app_name}}-deployment -n {{fmt_app_name}}
+          kubectl rollout status deployment {{fmt_app_name}}-deployment   -n {{fmt_app_name}}          
+          # Exit with a non-zero status code to indicate pipeline failure
+          exit 1
+        else
+          echo "Helm Rollback also failed ..."
+          exit 1
+        fi
+      fi
+    {% endif %}
       kubectl rollout restart deployment {{fmt_app_name}}-deployment -n {{fmt_app_name}}
       kubectl rollout status deployment {{fmt_app_name}}-deployment   -n {{fmt_app_name}}
   - name: 'gcr.io/cloud-builders/gcloud'

--- a/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
@@ -261,7 +261,7 @@ template: |
     {% if rollback_enable %}
       #Get Status code
       helm_upgrade_exit_status=$?
-      echo 'Helm release failed with EXIT_CODE: '$helm_upgrade_exit_status''
+      echo 'Helm release status of EXIT_CODE: '$helm_upgrade_exit_status''
       # Check the Helm upgrade/install status
       if [ $helm_upgrade_exit_status -eq 0 ]; then
         echo "Helm upgrade/install successful...."

--- a/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/basic-gke-regional.yaml
@@ -266,7 +266,7 @@ template: |
       if [ $helm_upgrade_exit_status -eq 0 ]; then
         echo "Helm upgrade/install successful...."
       else
-        #If helm release failed than rollback
+        # Helm upgrade/install failed
         echo "Helm upgrade/install failed. Rolling back pervious version..."
         
         # Perform the Helm rollback

--- a/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
@@ -483,7 +483,7 @@ template: |
     {% if rollback_enable %}
       #Get Status code
       helm_upgrade_exit_status=$?
-      echo 'Helm release failed with EXIT_CODE: '$helm_upgrade_exit_status''
+      echo 'Helm release status of EXIT_CODE: '$helm_upgrade_exit_status''
       # Check the Helm upgrade/install status
       if [ $helm_upgrade_exit_status -eq 0 ]; then
         echo "Helm upgrade/install successful...."

--- a/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
@@ -8,7 +8,7 @@ target: "deployment-template"
 keywords:
   - bash
   - linux
-author: CloudCover
+author: Ollion
 meta:
   inputArtifactType:
     - ContainerImage

--- a/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
@@ -488,7 +488,7 @@ template: |
       if [ $helm_upgrade_exit_status -eq 0 ]; then
         echo "Helm upgrade/install successful...."
       else
-        #If helm release failed than rollback
+        # Helm upgrade/install failed
         echo "Helm upgrade/install failed. Rolling back pervious version..."
         
         # Perform the Helm rollback

--- a/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
@@ -8,13 +8,18 @@ target: "deployment-template"
 keywords:
   - bash
   - linux
-author: Ollion
+author: CloudCover
 meta:
   inputArtifactType:
     - ContainerImage
 
 inputs:
   properties:
+    rollback_enable:
+      title: Enable Automatic Rollback
+      description: Enabling this option will automatically trigger a rollback of the Helm release in case of deployment failure during the previous deployment.
+      type: boolean
+      default: true
     istioInjection:
       title: Istio Injection Enabled
       description: Enable Istio Injection in namespace
@@ -373,9 +378,9 @@ template: |
         registryCredentials:
           registry: $$docker_registry
           username: $$docker_username" >> values.yaml
-
+     
       printf '    password: %s\n' "$(printf '%s' "$docker_password" | jq -aRs .)" >> values.yaml
-
+      
       echo "
       {% endif %}
       {% if ports %}
@@ -474,9 +479,37 @@ template: |
     - '-c'
     - |
       cd {{helm_chart_path}} ;
-      helm upgrade --install -f values.yaml {{service_name}} . --atomic --timeout {{deployment_timeout}}
+      helm upgrade --install -f values.yaml {{service_name}} . --wait --timeout {{deployment_timeout}}
+    {% if rollback_enable %}
+      #Get Status code
+      helm_upgrade_exit_status=$?
+      echo 'Helm release failed with EXIT_CODE: '$helm_upgrade_exit_status''
+      # Check the Helm upgrade/install status
+      if [ $helm_upgrade_exit_status -eq 0 ]; then
+        echo "Helm upgrade/install successful...."
+      else
+        #If helm release failed than rollback
+        echo "Helm upgrade/install failed. Rolling back pervious version..."
+        
+        # Perform the Helm rollback
+        helm  rollback {{service_name}}  0 --wait --timeout {{deployment_timeout}}
+        if [ $? -eq 0 ]; then
+          echo "Helm rollback completed..."
+          echo "Action Required: Check your deployment  on k8s cluster why it Rollbacked"
+          kubectl rollout restart deployment {{fmt_app_name}}-deployment -n {{fmt_app_name}}
+          kubectl rollout status deployment {{fmt_app_name}}-deployment   -n {{fmt_app_name}}          
+          # Exit with a non-zero status code to indicate pipeline failure
+          exit 1
+        else
+          echo "Helm Rollback also failed ..."
+          exit 1
+        fi
+      fi
+    {% endif %}
+      #Restarting the deployment to pick the recent change to running pod
       kubectl rollout restart deployment {{fmt_app_name}}-deployment -n {{fmt_app_name}}
       kubectl rollout status deployment {{fmt_app_name}}-deployment   -n {{fmt_app_name}}
+
   - id: 'Extract summary vars'
     name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'

--- a/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
+++ b/pipeline-modules/deployment-service/gcp/istio-gke-regional.yaml
@@ -494,7 +494,7 @@ template: |
         # Perform the Helm rollback
         helm  rollback {{service_name}}  0 --wait --timeout {{deployment_timeout}}
         if [ $? -eq 0 ]; then
-          echo "Helm rollback completed..."
+          echo "Helm Rollback completed..."
           echo "Action Required: Check your deployment  on k8s cluster why it Rollbacked"
           kubectl rollout restart deployment {{fmt_app_name}}-deployment -n {{fmt_app_name}}
           kubectl rollout status deployment {{fmt_app_name}}-deployment   -n {{fmt_app_name}}          


### PR DESCRIPTION
**Issue Discovery:**
In our CodePipes setup, I've observed that when we're deploying changes to our Stance application using Helm in a Kubernetes cluster, there's a safety mechanism in place. If a pod enters a crash loop for a continuous period of 300 seconds, it triggers an automatic rollback to the previous version.

```bash
helm upgrade --install -f values.yaml <release-name> . --atomic --timeout 300s
```

However, it's crucial to be aware that sometimes, even after a successful rollback, if the subsequent deployment attempt fails, the pipeline may still be marked as successful. This can be confusing for users as they may not immediately realize that Helm executed a rollback due to a failed deployment.

**Proposed Pull Request (PR):**
This PR aims to address the above-mentioned issues by introducing the following changes:

1. **Rollback Option Control:** We'll provide users with the ability to enable or disable the Helm rollback option on release failure. This gives users more control over the rollback mechanism based on their specific needs.

2. **Enhanced Handling of Rollbacks:** To tackle the issue where a failed deployment is not adequately reflected in the pipeline status, we will enhance our handling of Helm rollbacks. Now, if a Helm deployment fails for any reason, we will automatically trigger a rollback of the release and explicitly mark the pipeline as failed. This ensures that a failed deployment is immediately noticeable, preventing any confusion.

These changes will make our deployment process more transparent, robust, and aligned with users' expectations.