### PR TITLE
VAN-4378 Add variable to control Azure deployment

### DIFF
--- a/build-pipeline/staging-release.yml
+++ b/build-pipeline/staging-release.yml
@@ -38,6 +38,9 @@ stages:
       name: Azure-Agents
     variables:
       - group: CodePipes-AZStaging-DB
+      - group: CodePipes-Azure-Staging-Deploy
+    # enableAzureStagingDeploy is defined in CodePipes-Azure-Staging-Deploy group
+    condition: eq(variables.enableAzureStagingDeploy, true)
 
     jobs:
       - job: Release_AZ_Staging


### PR DESCRIPTION
Deployment to Azure staging is now controlled via variable "enableAzureStagingDeploy" which is defined in an AZDO variable group.