### PR TITLE
VAN-4417 Update basic-eks-regional.yaml as script was failing

### DIFF
--- a/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
+++ b/pipeline-modules/deployment-service/aws/basic-eks-regional.yaml
@@ -344,7 +344,7 @@ template: |
         - cd {{workspace}}
         - |
           echo 'kubectl get ingress -n {{ fmt_app_name | cpi_quote }} -o=jsonpath={{ kube_out_path| cpi_quote }} | tr -d \"' > cmd.sh
-          summary=$(retry.sh run "bash ./cmd.sh" 30 2)
+          summary=$(./retry.sh run "bash ./cmd.sh" 30 2)
         - outputs.sh add "Service URL" "{{url_protocol}}://$summary"
           {% endif %}
       {% else %}


### PR DESCRIPTION
AWS Infra Deployment is failing with the following error :  

`An unexpected error occurred: build has finished with status 'Failure': 'FAILED' (COMMAND_EXECUTION_ERROR) in 'BUILD': Error while executing command: echo 'kubectl get ingress -n "cldcvr-vanguard-demo-52dd07" -o=jsonpath="{.items[*].status.loadBalancer.ingress[*].hostname}" | tr -d \"' > cmd.sh

summary=$(retry.sh run "bash ./cmd.sh" 30 2)

. Reason: exit status 1`